### PR TITLE
Use arrow functions in test suite

### DIFF
--- a/src/__tests__/main-test.js
+++ b/src/__tests__/main-test.js
@@ -34,16 +34,16 @@ var source = [
   'module.exports = Component;'
 ].join('\n');
 
-describe('main', function() {
+describe('main', () => {
   var utils;
   var docgen;
 
-  beforeEach(function() {
+  beforeEach(() => {
     utils = require('../../tests/utils');
     docgen = require('../main');
   });
 
-  it('parses with default resolver/handlers', function() {
+  it('parses with default resolver/handlers', () => {
     var docs = docgen.parse(source);
     expect(docs).toEqual({
       description: 'Example component description',
@@ -63,7 +63,7 @@ describe('main', function() {
     });
   });
 
-  it('parses with custom handlers', function() {
+  it('parses with custom handlers', () => {
     var docs = docgen.parse(source, null, [
       docgen.handlers.componentDocblockHandler,
     ]);

--- a/src/__tests__/parse-test.js
+++ b/src/__tests__/parse-test.js
@@ -12,11 +12,11 @@
 
 jest.autoMockOff();
 
-describe('parse', function() {
+describe('parse', () => {
   var utils;
   var parse;
 
-  beforeEach(function() {
+  beforeEach(() => {
     utils = require('../../tests/utils');
     parse = require('../parse');
   });
@@ -25,7 +25,7 @@ describe('parse', function() {
     return utils.parse(source).get('body', 0, 'expression');
   }
 
-  it('allows custom component definition resolvers', function() {
+  it('allows custom component definition resolvers', () => {
     var path = pathFromSource('({foo: "bar"})');
     var resolver = jest.genMockFunction().mockReturnValue(path);
     var handler = jest.genMockFunction();
@@ -35,7 +35,7 @@ describe('parse', function() {
     expect(handler.mock.calls[0][1]).toBe(path);
   });
 
-  it('errors if component definition is not found', function() {
+  it('errors if component definition is not found', () => {
     var resolver = jest.genMockFunction();
     expect(function() {
       parse('', resolver);

--- a/src/handlers/__tests__/componentDocblockHandler-test.js
+++ b/src/handlers/__tests__/componentDocblockHandler-test.js
@@ -13,7 +13,7 @@
 jest.autoMockOff();
 jest.mock('../../Documentation');
 
-describe('componentDocblockHandler', function() {
+describe('componentDocblockHandler', () => {
   var utils;
   var documentation;
   var componentDocblockHandler;
@@ -31,13 +31,13 @@ describe('componentDocblockHandler', function() {
     );
   }
 
-  beforeEach(function() {
+  beforeEach(() => {
     utils = require('../../../tests/utils');
     documentation = new (require('../../Documentation'));
     componentDocblockHandler = require('../componentDocblockHandler');
   });
 
-  it('finds docblocks for component definitions', function() {
+  it('finds docblocks for component definitions', () => {
     var definition = parse([
       '/**',
       ' * Component description',
@@ -49,7 +49,7 @@ describe('componentDocblockHandler', function() {
     expect(documentation.description).toBe('Component description');
   });
 
-  it('ignores other types of comments', function() {
+  it('ignores other types of comments', () => {
     var definition = parse([
       '/*',
       ' * This is not a docblock',
@@ -69,7 +69,7 @@ describe('componentDocblockHandler', function() {
     expect(documentation.description).toBe('');
   });
 
-  it('only considers the docblock directly above the definition', function() {
+  it('only considers the docblock directly above the definition', () => {
     var definition = parse([
       '/**',
       ' * This is the wrong docblock',

--- a/src/handlers/__tests__/defaultPropsHandler-test.js
+++ b/src/handlers/__tests__/defaultPropsHandler-test.js
@@ -13,7 +13,7 @@
 jest.autoMockOff();
 jest.mock('../../Documentation');
 
-describe('defaultPropsHandler', function() {
+describe('defaultPropsHandler', () => {
   var utils;
   var documentation;
   var defaultValueHandler;
@@ -22,13 +22,13 @@ describe('defaultPropsHandler', function() {
     return utils.parse(src).get('body', 0, 'expression');
   }
 
-  beforeEach(function() {
+  beforeEach(() => {
     utils = require('../../../tests/utils');
     documentation = new (require('../../Documentation'));
     defaultPropsHandler = require('../defaultPropsHandler');
   });
 
-  it ('should find prop default values that are literals', function() {
+  it ('should find prop default values that are literals', () => {
     var definition = parse([
       '({',
       '  getDefaultProps: function() {',

--- a/src/handlers/__tests__/propDocblockHandler-test.js
+++ b/src/handlers/__tests__/propDocblockHandler-test.js
@@ -13,12 +13,12 @@
 jest.autoMockOff();
 jest.mock('../../Documentation');
 
-describe('propDocblockHandler', function() {
+describe('propDocblockHandler', () => {
   var utils;
   var documentation;
   var propDocblockHandler;
 
-  beforeEach(function() {
+  beforeEach(() => {
     utils = require('../../../tests/utils');
     documentation = new (require('../../Documentation'));
     propDocblockHandler = require('../propDocblockHandler');
@@ -33,7 +33,7 @@ describe('propDocblockHandler', function() {
     );
   }
 
-  it('finds docblocks for prop types', function() {
+  it('finds docblocks for prop types', () => {
     var definition = parse([
       '({',
       '  propTypes: {',
@@ -61,7 +61,7 @@ describe('propDocblockHandler', function() {
     });
   });
 
-  it('can handle multline comments', function() {
+  it('can handle multline comments', () => {
     var definition = parse([
       '({',
       '  propTypes: {',
@@ -85,7 +85,7 @@ describe('propDocblockHandler', function() {
     });
   });
 
-  it('ignores non-docblock comments', function() {
+  it('ignores non-docblock comments', () => {
     var definition = parse([
       '({',
       '  propTypes: {',
@@ -115,7 +115,7 @@ describe('propDocblockHandler', function() {
     });
   });
 
-  it('only considers the comment with the property below it', function() {
+  it('only considers the comment with the property below it', () => {
     var definition = parse([
       '({',
       '  propTypes: {',
@@ -139,7 +139,7 @@ describe('propDocblockHandler', function() {
     });
   });
 
-  it('understands and ignores the spread operator', function() {
+  it('understands and ignores the spread operator', () => {
     var definition = parse([
       '({',
       '  propTypes: {',
@@ -160,7 +160,7 @@ describe('propDocblockHandler', function() {
     });
   });
 
-  it('resolves variables', function() {
+  it('resolves variables', () => {
     var definition = parse([
       'var Props = {',
       '  /**',
@@ -181,7 +181,7 @@ describe('propDocblockHandler', function() {
     });
   });
 
-  it('does not error if propTypes cannot be found', function() {
+  it('does not error if propTypes cannot be found', () => {
     var definition = parse([
       '({',
       '  fooBar: 42',

--- a/src/handlers/__tests__/propTypeHandler-test.js
+++ b/src/handlers/__tests__/propTypeHandler-test.js
@@ -13,13 +13,13 @@
 jest.autoMockOff();
 jest.mock('../../Documentation');
 
-describe('propTypeHandler', function() {
+describe('propTypeHandler', () => {
   var utils;
   var getPropTypeMock;
   var documentation;
   var propTypeHandler;
 
-  beforeEach(function() {
+  beforeEach(() => {
     utils = require('../../../tests/utils');
     getPropTypeMock = jest.genMockFunction().mockImplementation(() => ({}));
     jest.setMock('../../utils/getPropType', getPropTypeMock);
@@ -38,7 +38,7 @@ describe('propTypeHandler', function() {
     );
   }
 
-  it('passes the correct argument to getPropType', function() {
+  it('passes the correct argument to getPropType', () => {
     var definition = parse(
       '({propTypes: {foo: PropTypes.bool, abc: PropTypes.xyz}})'
     );
@@ -52,7 +52,7 @@ describe('propTypeHandler', function() {
     expect(getPropTypeMock).toBeCalledWith(xyzPath);
   });
 
-  it('finds definitions via React.PropTypes', function() {
+  it('finds definitions via React.PropTypes', () => {
     var definition = parse([
       '({',
       '  propTypes: {',
@@ -76,7 +76,7 @@ describe('propTypeHandler', function() {
     });
   });
 
-  it('finds definitions via the ReactPropTypes module', function() {
+  it('finds definitions via the ReactPropTypes module', () => {
     var definition = parse([
       '({',
       '  propTypes: {',
@@ -95,7 +95,7 @@ describe('propTypeHandler', function() {
     });
   });
 
-  it('detects whether a prop is required', function() {
+  it('detects whether a prop is required', () => {
     var definition = parse([
       '({',
       '  propTypes: {',
@@ -119,7 +119,7 @@ describe('propTypeHandler', function() {
     });
   });
 
-  it('only considers definitions from React or ReactPropTypes', function() {
+  it('only considers definitions from React or ReactPropTypes', () => {
     var definition = parse([
       '({',
       '  propTypes: {',
@@ -145,7 +145,7 @@ describe('propTypeHandler', function() {
     });
   });
 
-  it('understands the spread operator', function() {
+  it('understands the spread operator', () => {
     var definition = parse([
       'var Foo = require("Foo.react");',
       'var props = {bar: PropTypes.bool};',
@@ -172,7 +172,7 @@ describe('propTypeHandler', function() {
     });
   });
 
-  it('resolves variables', function() {
+  it('resolves variables', () => {
     var definition = parse([
       'var props = {bar: PropTypes.bool};',
       '({',
@@ -189,7 +189,7 @@ describe('propTypeHandler', function() {
     });
   });
 
-  it('does not error if propTypes cannot be found', function() {
+  it('does not error if propTypes cannot be found', () => {
     var definition = parse([
       '({',
       '  fooBar: 42',

--- a/src/resolver/__tests__/findAllReactCreateClassCalls-test.js
+++ b/src/resolver/__tests__/findAllReactCreateClassCalls-test.js
@@ -12,7 +12,7 @@
 
 jest.autoMockOff();
 
-describe('React documentation parser', function() {
+describe('React documentation parser', () => {
   var findAllReactCreateClassCalls;
   var recast;
 
@@ -23,13 +23,13 @@ describe('React documentation parser', function() {
     );
   }
 
-  beforeEach(function() {
+  beforeEach(() => {
     findAllReactCreateClassCalls = require('../findAllReactCreateClassCalls');
     recast = require('recast');
   });
 
 
-  it('finds React.createClass', function() {
+  it('finds React.createClass', () => {
     var source = [
       'var React = require("React");',
       'var Component = React.createClass({});',
@@ -43,7 +43,7 @@ describe('React documentation parser', function() {
     expect(result[0].node.type).toBe('ObjectExpression');
   });
 
-  it('finds React.createClass, independent of the var name', function() {
+  it('finds React.createClass, independent of the var name', () => {
     var source = [
       'var R = require("React");',
       'var Component = R.createClass({});',
@@ -55,7 +55,7 @@ describe('React documentation parser', function() {
     expect(result.length).toBe(1);
   });
 
-  it('does not process X.createClass of other modules', function() {
+  it('does not process X.createClass of other modules', () => {
     var source = [
       'var R = require("NoReact");',
       'var Component = R.createClass({});',
@@ -67,7 +67,7 @@ describe('React documentation parser', function() {
     expect(result.length).toBe(0);
   });
 
-  it('finds assignments to exports', function() {
+  it('finds assignments to exports', () => {
     var source = [
       'var R = require("React");',
       'var Component = R.createClass({});',
@@ -80,7 +80,7 @@ describe('React documentation parser', function() {
     expect(result.length).toBe(1);
   });
 
-  it('accepts multiple definitions', function() {
+  it('accepts multiple definitions', () => {
     var source = [
       'var R = require("React");',
       'var ComponentA = R.createClass({});',

--- a/src/resolver/__tests__/findExportedReactCreateClassCall-test.js
+++ b/src/resolver/__tests__/findExportedReactCreateClassCall-test.js
@@ -12,7 +12,7 @@
 
 jest.autoMockOff();
 
-describe('React documentation parser', function() {
+describe('React documentation parser', () => {
   var findExportedReactCreateClass;
   var recast;
 
@@ -23,13 +23,13 @@ describe('React documentation parser', function() {
     );
   }
 
-  beforeEach(function() {
+  beforeEach(() => {
     findExportedReactCreateClass =
       require('../findExportedReactCreateClassCall');
     recast = require('recast');
   });
 
-  it('finds React.createClass', function() {
+  it('finds React.createClass', () => {
     var source = [
       'var React = require("React");',
       'var Component = React.createClass({});',
@@ -39,7 +39,7 @@ describe('React documentation parser', function() {
     expect(parse(source)).toBeDefined();
   });
 
-  it('finds React.createClass, independent of the var name', function() {
+  it('finds React.createClass, independent of the var name', () => {
     var source = [
       'var R = require("React");',
       'var Component = R.createClass({});',
@@ -49,7 +49,7 @@ describe('React documentation parser', function() {
     expect(parse(source)).toBeDefined();
   });
 
-  it('does not process X.createClass of other modules', function() {
+  it('does not process X.createClass of other modules', () => {
     var source = [
       'var R = require("NoReact");',
       'var Component = R.createClass({});',
@@ -59,7 +59,7 @@ describe('React documentation parser', function() {
     expect(parse(source)).toBeUndefined();
   });
 
-  it('finds assignments to exports', function() {
+  it('finds assignments to exports', () => {
     var source = [
       'var R = require("React");',
       'var Component = R.createClass({});',
@@ -70,7 +70,7 @@ describe('React documentation parser', function() {
     expect(parse(source)).toBeDefined();
   });
 
-  it('errors if multiple components are exported', function() {
+  it('errors if multiple components are exported', () => {
     var source = [
       'var R = require("React");',
       'var ComponentA = R.createClass({});',
@@ -84,7 +84,7 @@ describe('React documentation parser', function() {
     }).toThrow();
   });
 
-  it('accepts multiple definitions if only one is exported', function() {
+  it('accepts multiple definitions if only one is exported', () => {
     var source = [
       'var R = require("React");',
       'var ComponentA = R.createClass({});',

--- a/src/utils/__tests__/docblock-test.js
+++ b/src/utils/__tests__/docblock-test.js
@@ -12,26 +12,26 @@
 
 jest.autoMockOff();
 
-describe('docblock', function() {
+describe('docblock', () => {
 
-  describe('getDoclets', function() {
+  describe('getDoclets', () => {
     var getDoclets;
 
-    beforeEach(function() {
+    beforeEach(() => {
       getDoclets = require('../docblock').getDoclets;
     });
 
-    it('extracts single line doclets', function() {
+    it('extracts single line doclets', () => {
       expect(getDoclets('@foo bar\n@bar baz'))
         .toEqual({foo: 'bar', bar: 'baz'});
     });
 
-    it('extracts multi line doclets', function() {
+    it('extracts multi line doclets', () => {
       expect(getDoclets('@foo bar\nbaz\n@bar baz'))
         .toEqual({foo: 'bar\nbaz', bar: 'baz'});
     });
 
-    it('extracts boolean doclets', function() {
+    it('extracts boolean doclets', () => {
       expect(getDoclets('@foo bar\nbaz\n@abc\n@bar baz'))
         .toEqual({foo: 'bar\nbaz', abc: true, bar: 'baz'});
     });

--- a/src/utils/__tests__/getMembers-test.js
+++ b/src/utils/__tests__/getMembers-test.js
@@ -12,7 +12,7 @@
 
 jest.autoMockOff();
 
-describe('getMembers', function() {
+describe('getMembers', () => {
   var recast;
   var getMembers;
   var memberExpressionPath;
@@ -23,14 +23,14 @@ describe('getMembers', function() {
     );
   }
 
-  beforeEach(function() {
+  beforeEach(() => {
     getMembers = require('../getMembers');
     recast = require('recast');
     memberExpressionPath = parse('foo.bar(123)(456)[baz][42]');
   });
 
 
-  it('finds all "members" "inside" a MemberExpression', function() {
+  it('finds all "members" "inside" a MemberExpression', () => {
     var b = recast.types.builders;
     var members = getMembers(memberExpressionPath);
 

--- a/src/utils/__tests__/getPropType-test.js
+++ b/src/utils/__tests__/getPropType-test.js
@@ -12,7 +12,7 @@
 
 jest.autoMockOff();
 
-describe('getPropType', function() {
+describe('getPropType', () => {
   var utils;
   var getPropType;
 
@@ -20,12 +20,12 @@ describe('getPropType', function() {
     return utils.parse(src).get('body', 0, 'expression');
   }
 
-  beforeEach(function() {
+  beforeEach(() => {
     getPropType = require('../getPropType');
     utils = require('../../../tests/utils');
   });
 
-  it('detects simple prop types', function() {
+  it('detects simple prop types', () => {
     var simplePropTypes = [
       'array',
       'bool',
@@ -56,7 +56,7 @@ describe('getPropType', function() {
     );
   });
 
-  it('detects complex prop types', function() {
+  it('detects complex prop types', () => {
     expect(getPropType(parse('oneOf(["foo", "bar"])'))).toEqual({
       name: 'enum',
       value: [
@@ -123,7 +123,7 @@ describe('getPropType', function() {
     });
   });
 
-  it('resolves variables to their values', function() {
+  it('resolves variables to their values', () => {
     var src = [
       'var shape = {bar: PropTypes.string};',
       'PropTypes.shape(shape);',
@@ -138,7 +138,7 @@ describe('getPropType', function() {
     });
   });
 
-  it('detects custom validation functions', function() {
+  it('detects custom validation functions', () => {
     expect(getPropType(parse('(function() {})'))).toEqual({
       name: 'custom',
       raw: '(function() {})'

--- a/src/utils/__tests__/getPropertyValuePath-test.js
+++ b/src/utils/__tests__/getPropertyValuePath-test.js
@@ -12,7 +12,7 @@
 
 jest.autoMockOff();
 
-describe('getPropertyValuePath', function() {
+describe('getPropertyValuePath', () => {
   var recast;
   var getPropertyValuePath;
 
@@ -22,18 +22,18 @@ describe('getPropertyValuePath', function() {
     );
   }
 
-  beforeEach(function() {
+  beforeEach(() => {
     getPropertyValuePath = require('../getPropertyValuePath');
     recast = require('recast');
   });
 
-  it('returns the value path if the property exists', function() {
+  it('returns the value path if the property exists', () => {
     var objectExpressionPath = parse('({foo: 21, bar: 42})').get('expression');
     expect(getPropertyValuePath(objectExpressionPath, 'bar'))
       .toBe(objectExpressionPath.get('properties', 1).get('value'));
   });
 
-  it('returns undefined if the property does not exist', function() {
+  it('returns undefined if the property does not exist', () => {
     var objectExpressionPath = parse('({foo: 21, bar: 42})').get('expression');
     expect(getPropertyValuePath(objectExpressionPath, 'baz'))
       .toBeUndefined();

--- a/src/utils/__tests__/isExportsOrModuleAssignment-test.js
+++ b/src/utils/__tests__/isExportsOrModuleAssignment-test.js
@@ -12,7 +12,7 @@
 
 jest.autoMockOff();
 
-describe('isExportsOrModuleAssignment', function() {
+describe('isExportsOrModuleAssignment', () => {
   var recast;
   var isExportsOrModuleAssignment;
 
@@ -22,22 +22,22 @@ describe('isExportsOrModuleAssignment', function() {
     );
   }
 
-  beforeEach(function() {
+  beforeEach(() => {
     isExportsOrModuleAssignment = require('../isExportsOrModuleAssignment');
     recast = require('recast');
   });
 
-  it('detects "module.exports = ...;"', function() {
+  it('detects "module.exports = ...;"', () => {
     expect(isExportsOrModuleAssignment(parse('module.exports = foo;')))
       .toBe(true);
   });
 
-  it('detects "exports.foo = ..."', function() {
+  it('detects "exports.foo = ..."', () => {
     expect(isExportsOrModuleAssignment(parse('exports.foo = foo;')))
       .toBe(true);
   });
 
-  it('does not accept "exports = foo;"', function() {
+  it('does not accept "exports = foo;"', () => {
     // That doesn't actually export anything
     expect(isExportsOrModuleAssignment(parse('exports = foo;')))
       .toBe(false);

--- a/src/utils/__tests__/match-test.js
+++ b/src/utils/__tests__/match-test.js
@@ -12,22 +12,22 @@
 
 jest.autoMockOff();
 
-describe('match', function() {
+describe('match', () => {
   var match;
 
-  beforeEach(function() {
+  beforeEach(() => {
     match = require('../match');
   });
 
-  it('matches with exact properties', function() {
+  it('matches with exact properties', () => {
     expect(match({foo: {bar: 42}}, {foo: {bar: 42}})).toBe(true);
   });
 
-  it('matches a subset of properties in the target', function() {
+  it('matches a subset of properties in the target', () => {
     expect(match({foo: {bar: 42, baz: "xyz"}}, {foo: {bar: 42}})).toBe(true);
   });
 
-  it('does not match if properties are different/missing', function() {
+  it('does not match if properties are different/missing', () => {
     expect(match(
       {foo: {bar: 42, baz: "xyz"}},
       {foo: {bar: 21, baz: "xyz"}}

--- a/src/utils/__tests__/printValue-test.js
+++ b/src/utils/__tests__/printValue-test.js
@@ -12,11 +12,11 @@
 
 jest.autoMockOff();
 
-describe('printValue', function() {
+describe('printValue', () => {
   var printValue;
   var utils;
 
-  beforeEach(function() {
+  beforeEach(() => {
     printValue = require('../printValue');
     utils = require('../../../tests/utils');
   });
@@ -25,12 +25,12 @@ describe('printValue', function() {
     return utils.parse(source).get('body', 0, 'expression');
   }
 
-  it('does not print leading comments', function() {
+  it('does not print leading comments', () => {
     expect(printValue(pathFromSource('//foo\nbar')))
       .toEqual('bar');
   });
 
-  it('does not print trailing comments', function() {
+  it('does not print trailing comments', () => {
     expect(printValue(pathFromSource('bar//foo')))
       .toEqual('bar');
   });


### PR DESCRIPTION
Using arrow functions in the test suite removes the "function" clutter
from the Jasmine DSL, making it easier to read.

Test plan: Run `npm test` and see everything continues to pass.