### PR TITLE
Stateless Components

### DIFF
--- a/src/__tests__/main-test.js
+++ b/src/__tests__/main-test.js
@@ -99,4 +99,81 @@ describe('main', () => {
     `);
   });
 
+  describe('Stateless Component definition: ArrowFunctionExpression', () => {
+    test(`
+      import React, {PropTypes} from "React";
+
+      /**
+        * Example component description
+        */
+      let Component = props => <div />;
+      Component.displayName = 'ABC';
+      Component.defaultProps = {
+          foo: true
+      };
+
+      Component.propTypes = {
+        /**
+        * Example prop description
+        */
+        foo: PropTypes.bool
+      };
+
+      export default Component;
+    `);
+  });
+
+  describe('Stateless Component definition: FunctionDeclaration', () => {
+    test(`
+      import React, {PropTypes} from "React";
+
+      /**
+      * Example component description
+      */
+      function Component (props) {
+        return <div />;
+      }
+
+      Component.displayName = 'ABC';
+      Component.defaultProps = {
+          foo: true
+      };
+
+      Component.propTypes = {
+        /**
+        * Example prop description
+        */
+        foo: PropTypes.bool
+      };
+
+      export default Component;
+    `);
+  });
+
+  describe('Stateless Component definition: FunctionExpression', () => {
+    test(`
+      import React, {PropTypes} from "React";
+
+      /**
+      * Example component description
+      */
+      let Component = function(props) {
+        return React.createElement('div', null);
+      }
+
+      Component.displayName = 'ABC';
+      Component.defaultProps = {
+          foo: true
+      };
+
+      Component.propTypes = {
+        /**
+        * Example prop description
+        */
+        foo: PropTypes.bool
+      };
+
+      export default Component;
+    `);
+  });
 });

--- a/src/__tests__/main-test.js
+++ b/src/__tests__/main-test.js
@@ -13,10 +13,11 @@
 jest.autoMockOff();
 
 describe('main', () => {
-  var docgen;
+  var docgen, ERROR_MISSING_DEFINITION;
 
   beforeEach(() => {
     docgen = require('../main');
+    ({ERROR_MISSING_DEFINITION} = require('../parse'));
   });
 
   function test(source) {
@@ -175,5 +176,38 @@ describe('main', () => {
 
       export default Component;
     `);
+  });
+
+  describe('Stateless Component definition', () => {
+    it('is not so greedy', () => {
+      const source = `
+        import React, {PropTypes} from "React";
+
+        /**
+        * Example component description
+        */
+        let NotAComponent = function(props) {
+          let HiddenComponent = () => React.createElement('div', null);
+
+          return 7;
+        }
+
+        NotAComponent.displayName = 'ABC';
+        NotAComponent.defaultProps = {
+            foo: true
+        };
+
+        NotAComponent.propTypes = {
+          /**
+          * Example prop description
+          */
+          foo: PropTypes.bool
+        };
+
+        export default NotAComponent;
+      `;
+
+      expect(() => docgen.parse(source)).toThrow(ERROR_MISSING_DEFINITION);
+    });
   });
 });

--- a/src/handlers/__tests__/propTypeHandler-test.js
+++ b/src/handlers/__tests__/propTypeHandler-test.js
@@ -184,6 +184,16 @@ describe('propTypeHandler', () => {
     );
   });
 
+  describe('stateless component', () => {
+    test(
+      propTypesSrc => template(`
+        var Component = (props) => <div />;
+        Component.propTypes = ${propTypesSrc};
+      `),
+      src => statement(src)
+    );
+  });
+
   it('does not error if propTypes cannot be found', () => {
     var definition = expression('{fooBar: 42}');
     expect(() => propTypeHandler(documentation, definition))

--- a/src/resolver/__tests__/findAllComponentDefinitions-test.js
+++ b/src/resolver/__tests__/findAllComponentDefinitions-test.js
@@ -168,11 +168,17 @@ describe('findAllComponentDefinitions', () => {
           var result = () => <div>{props.children}</div>;
           return result();
         };
+        const ComponentF = function(props) {
+          var helpers = {
+            comp() { return <div>{props.children}</div>; }
+          };
+          return helpers.comp();
+        };
       `;
 
       var result = parse(source);
       expect(Array.isArray(result)).toBe(true);
-      expect(result.length).toBe(6);
+      expect(result.length).toBe(7);
     });
 
     it('finds React.createElement, independent of the var name', () => {

--- a/src/resolver/__tests__/findAllComponentDefinitions-test.js
+++ b/src/resolver/__tests__/findAllComponentDefinitions-test.js
@@ -160,11 +160,15 @@ describe('findAllComponentDefinitions', () => {
         var Obj = {
           component() { if (true) { return <div />; } }
         };
+        const ComponentD = function(props) {
+          var result = <div>{props.children}</div>;
+          return result;
+        };
       `;
 
       var result = parse(source);
       expect(Array.isArray(result)).toBe(true);
-      expect(result.length).toBe(4);
+      expect(result.length).toBe(5);
     });
 
     it('finds React.createElement, independent of the var name', () => {

--- a/src/resolver/__tests__/findAllComponentDefinitions-test.js
+++ b/src/resolver/__tests__/findAllComponentDefinitions-test.js
@@ -149,4 +149,46 @@ describe('findAllComponentDefinitions', () => {
     });
   });
 
+  describe('stateless components', () => {
+
+    it('finds stateless components', () => {
+      var source = `
+        import React from 'React';
+        let ComponentA = () => <div />;
+        function ComponentB () { return React.createElement('div', null); }
+        const ComponentC = function(props) { return <div>{props.children}</div>; };
+        var Obj = {
+          component() { if (true) { return <div />; } }
+        };
+      `;
+
+      var result = parse(source);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(4);
+    });
+
+    it('finds React.createElement, independent of the var name', () => {
+      var source = `
+        import AlphaBetters from 'react';
+        function ComponentA () { return AlphaBetters.createElement('div', null); }
+        function ComponentB () { return 7; }
+      `;
+
+      var result = parse(source);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(1);
+    });
+
+    it('does not process X.createClass of other modules', () => {
+      var source = `
+        import R from 'FakeReact';
+        const ComponentA = () => R.createElement('div', null);
+      `;
+
+      var result = parse(source);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(0);
+    });
+  });
+
 });

--- a/src/resolver/__tests__/findAllComponentDefinitions-test.js
+++ b/src/resolver/__tests__/findAllComponentDefinitions-test.js
@@ -164,11 +164,15 @@ describe('findAllComponentDefinitions', () => {
           var result = <div>{props.children}</div>;
           return result;
         };
+        const ComponentE = function(props) {
+          var result = () => <div>{props.children}</div>;
+          return result();
+        };
       `;
 
       var result = parse(source);
       expect(Array.isArray(result)).toBe(true);
-      expect(result.length).toBe(5);
+      expect(result.length).toBe(6);
     });
 
     it('finds React.createElement, independent of the var name', () => {

--- a/src/resolver/findAllComponentDefinitions.js
+++ b/src/resolver/findAllComponentDefinitions.js
@@ -12,6 +12,7 @@
 
 import isReactComponentClass from '../utils/isReactComponentClass';
 import isReactCreateClassCall from '../utils/isReactCreateClassCall';
+import isStatelessComponent from '../utils/isStatelessComponent';
 import normalizeClassDefinition from '../utils/normalizeClassDefinition';
 import resolveToValue from '../utils/resolveToValue';
 
@@ -34,7 +35,19 @@ export default function findAllReactCreateClassCalls(
     return false;
   }
 
+  function statelessVisitor(path) {
+    if (isStatelessComponent(path)) {
+      // TODO: normalizeStatelessDefinition to pick up propTypes
+      definitions.push(path);
+    }
+    return false;
+  }
+
   recast.visit(ast, {
+    visitFunctionDeclaration: statelessVisitor,
+    visitFunctionExpression: statelessVisitor,
+    visitProperty: statelessVisitor,
+    visitArrowFunctionExpression: statelessVisitor,
     visitClassExpression: classVisitor,
     visitClassDeclaration: classVisitor,
     visitCallExpression: function(path) {

--- a/src/resolver/findAllComponentDefinitions.js
+++ b/src/resolver/findAllComponentDefinitions.js
@@ -46,7 +46,6 @@ export default function findAllReactCreateClassCalls(
   recast.visit(ast, {
     visitFunctionDeclaration: statelessVisitor,
     visitFunctionExpression: statelessVisitor,
-    visitProperty: statelessVisitor,
     visitArrowFunctionExpression: statelessVisitor,
     visitClassExpression: classVisitor,
     visitClassDeclaration: classVisitor,

--- a/src/resolver/findAllComponentDefinitions.js
+++ b/src/resolver/findAllComponentDefinitions.js
@@ -37,7 +37,6 @@ export default function findAllReactCreateClassCalls(
 
   function statelessVisitor(path) {
     if (isStatelessComponent(path)) {
-      // TODO: normalizeStatelessDefinition to pick up propTypes
       definitions.push(path);
     }
     return false;

--- a/src/resolver/findExportedComponentDefinition.js
+++ b/src/resolver/findExportedComponentDefinition.js
@@ -12,6 +12,7 @@
 import isExportsOrModuleAssignment from '../utils/isExportsOrModuleAssignment';
 import isReactComponentClass from '../utils/isReactComponentClass';
 import isReactCreateClassCall from '../utils/isReactCreateClassCall';
+import isStatelessComponent from '../utils/isStatelessComponent';
 import normalizeClassDefinition from '../utils/normalizeClassDefinition';
 import resolveExportDeclaration from '../utils/resolveExportDeclaration';
 import resolveToValue from '../utils/resolveToValue';
@@ -79,7 +80,11 @@ export default function findExportedComponentDefinition(
   }
 
   recast.visit(ast, {
-    visitFunctionDeclaration: ignore,
+    visitFunctionDeclaration: function(path) {
+      if (isStatelessComponent(path)) {
+        definition = resolveDefinition(path, types);
+      }
+    },
     visitFunctionExpression: ignore,
     visitClassDeclaration: ignore,
     visitClassExpression: ignore,

--- a/src/resolver/findExportedComponentDefinition.js
+++ b/src/resolver/findExportedComponentDefinition.js
@@ -25,7 +25,7 @@ function ignore() {
 }
 
 function isComponentDefinition(path) {
-  return isReactCreateClassCall(path) || isReactComponentClass(path);
+  return isReactCreateClassCall(path) || isReactComponentClass(path) || isStatelessComponent(path);
 }
 
 function resolveDefinition(definition, types) {
@@ -37,6 +37,8 @@ function resolveDefinition(definition, types) {
     }
   } else if(isReactComponentClass(definition)) {
     normalizeClassDefinition(definition);
+    return definition;
+  } else if (isStatelessComponent(definition)) {
     return definition;
   }
   return null;
@@ -52,7 +54,7 @@ function resolveDefinition(definition, types) {
  * If a definition is part of the following statements, it is considered to be
  * exported:
  *
- * modules.exports = Defintion;
+ * modules.exports = Definition;
  * exports.foo = Definition;
  * export default Definition;
  * export var Definition = ...;
@@ -80,11 +82,7 @@ export default function findExportedComponentDefinition(
   }
 
   recast.visit(ast, {
-    visitFunctionDeclaration: function(path) {
-      if (isStatelessComponent(path)) {
-        definition = resolveDefinition(path, types);
-      }
-    },
+    visitFunctionDeclaration: ignore,
     visitFunctionExpression: ignore,
     visitClassDeclaration: ignore,
     visitClassExpression: ignore,

--- a/src/utils/__tests__/getMemberExpressionValuePath-test.js
+++ b/src/utils/__tests__/getMemberExpressionValuePath-test.js
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+/*global jest, describe, beforeEach, it, expect*/
+
+jest.autoMockOff();
+var recast = require('recast');
+
+describe('getMemberExpressionValuePath', () => {
+  var getMemberExpressionValuePath;
+  var statement;
+
+  beforeEach(() => {
+    getMemberExpressionValuePath = require('../getMemberExpressionValuePath');
+    ({statement} = require('../../../tests/utils'));
+  });
+
+  describe('MethodExpression', () => {
+    it('finds "normal" property definitions', () => {
+      var def = statement(`
+        var Foo = () => {};
+        Foo.propTypes = {};
+      `);
+
+      expect(getMemberExpressionValuePath(def, 'propTypes'))
+        .toBe(def.parent.get('body', 1, 'expression', 'right'));
+    });
+
+    it('finds computed property definitions with literal keys', () => {
+      var def = statement(`
+        function Foo () {}
+        Foo['render'] = () => {};
+      `);
+
+      expect(getMemberExpressionValuePath(def, 'render'))
+        .toBe(def.parent.get('body', 1, 'expression', 'right'));
+    });
+
+    it('ignores computed property definitions with expression', () => {
+      var def = statement(`
+        var Foo = function Bar() {};
+        Foo[imComputed] = () => {};
+      `);
+
+      expect(getMemberExpressionValuePath(def, 'imComputed')).not.toBeDefined();
+    });
+  });
+});

--- a/src/utils/__tests__/isStatelessComponent-test.js
+++ b/src/utils/__tests__/isStatelessComponent-test.js
@@ -147,5 +147,67 @@ describe('isStatelessComponent', () => {
       expect(isStatelessComponent(def)).toBe(false);
     });
   });
+
+  describe('resolving return values', () => {
+    function test(desc, code) {
+      it(desc, () => {
+        var def = parse(code).get('body', 1);
+
+        expect(isStatelessComponent(def)).toBe(true);
+      });
+    }
+
+    test('handles simple resolves', `
+      var React = require('react');
+      function Foo (props) {
+        function bar() {
+          return React.createElement("div", props);
+        }
+
+        return bar();
+      }
+    `);
+
+    test('handles reference resolves', `
+      var React = require('react');
+      function Foo (props) {
+        var result = bar();
+
+        return result;
+
+        function bar() {
+          return <div />;
+        }
+      }
+    `);
+
+    test('handles shallow member call expression resolves', `
+      var React = require('react');
+      function Foo (props) {
+        var shallow = {
+          shallowMember() {
+            return <div />;
+          }
+        };
+
+        return shallow.shallowMember();
+      }
+    `);
+
+    test('handles deep member call expression resolves', `
+      var React = require('react');
+      function Foo (props) {
+        var obj = {
+          deep: {
+            member() {
+              return <div />;
+            }
+          }
+        };
+
+        return obj.deep.member();
+      }
+    `);
+  });
 });
 

--- a/src/utils/__tests__/isStatelessComponent-test.js
+++ b/src/utils/__tests__/isStatelessComponent-test.js
@@ -208,6 +208,46 @@ describe('isStatelessComponent', () => {
         return obj.deep.member();
       }
     `);
+
+    test('handles external reference member call expression resolves', `
+      var React = require('react');
+      function Foo (props) {
+        var member = () => <div />;
+        var obj = {
+          deep: {
+            member: member
+          }
+        };
+
+        return obj.deep.member();
+      }
+    `);
+
+    test('handles external reference member call expression resolves', `
+      var React = require('react');
+      function Foo (props) {
+        var member = () => <div />;
+        var obj = {
+          deep: {
+            member: member
+          }
+        };
+
+        return obj.deep.member();
+      }
+    `);
+
+    test('handles all sorts of JavaScript things', `
+      var React = require('react');
+      function Foo (props) {
+        var external = {
+          member: () => <div />
+        };
+        var obj = {external};
+
+        return obj.external.member();
+      }
+    `);
   });
 });
 

--- a/src/utils/__tests__/isStatelessComponent-test.js
+++ b/src/utils/__tests__/isStatelessComponent-test.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+/*global jest, describe, beforeEach, it, expect*/
+
+
+jest.autoMockOff();
+
+describe('isStatelessComponent', () => {
+  var isStatelessComponent;
+  var expression, statement, parse;
+
+  beforeEach(() => {
+    isStatelessComponent = require('../isStatelessComponent');
+    ({expression, statement, parse} = require('../../../tests/utils'));
+  });
+
+  describe('Stateless Function Components with JSX', () => {
+    it('accepts simple arrow function components', () => {
+      var def = parse(
+        'var Foo = () => <div />'
+      ).get('body', 0).get('declarations', [0]).get('init');
+      expect(isStatelessComponent(def)).toBe(true);
+    });
+
+    it('accepts simple function expressions components', () => {
+      var def = parse(
+        'let Foo = function() { return <div />; };'
+      ).get('body', 0).get('declarations', [0]).get('init');
+      expect(isStatelessComponent(def)).toBe(true);
+    });
+
+    it('accepts simple function declaration components', () => {
+      var def = parse('function Foo () { return <div /> }').get('body', 0);
+      expect(isStatelessComponent(def)).toBe(true);
+    });
+  });
+
+  describe('Stateless Function Components with React.createElement', () => {
+    it('accepts simple arrow function components', () => {
+      var def = parse(
+        'var Foo = () => React.creatElement("div", null);'
+      ).get('body', 0).get('declarations', [0]).get('init');
+
+      expect(isStatelessComponent(def)).toBe(true);
+    });
+
+    it('accepts simple function expressions components', () => {
+      var def = parse(
+        'let Foo = function() { return React.createElement("div", null); };'
+      ).get('body', 0).get('declarations', [0]).get('init');
+
+      expect(isStatelessComponent(def)).toBe(true);
+    });
+
+    it('accepts simple function declaration components', () => {
+      var def = parse('function Foo () { return React.createElement("div", null); }').get('body', 0);
+      expect(isStatelessComponent(def)).toBe(true);
+    });
+  });
+
+  describe('is not overzealous', () => {
+    it('does not accept declarations with a render method', () => {
+      var def = statement(`
+        class Foo {
+          render() {
+            return React.createElement('div', null);
+          }
+        }
+      `);
+      expect(isStatelessComponent(def)).toBe(false);
+    });
+
+    it('does not accept React.Component classes', () => {
+      var def = parse(`
+        var React = require('react');
+        class Foo extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+      `).get('body', 1);
+
+      expect(isStatelessComponent(def)).toBe(false);
+    });
+
+    it('does not accept React.createClass calls', () => {
+      var def = statement(`
+        React.createClass({
+          render() {
+            return <div />;
+          }
+        });
+      `);
+      expect(isStatelessComponent(def)).toBe(false);
+    });
+
+  });
+});
+

--- a/src/utils/__tests__/isStatelessComponent-test.js
+++ b/src/utils/__tests__/isStatelessComponent-test.js
@@ -128,6 +128,22 @@ describe('isStatelessComponent', () => {
           }
         });
       `);
+
+      expect(isStatelessComponent(def)).toBe(false);
+    });
+
+    it('does not mark containing functions as StatelessComponents', () => {
+      var def = parse(`
+        var React = require('react');
+        function Foo (props) {
+          function Bar() {
+            return React.createElement("div", props);
+          }
+
+          return {Bar}
+        }
+      `).get('body', 1);
+
       expect(isStatelessComponent(def)).toBe(false);
     });
   });

--- a/src/utils/__tests__/isStatelessComponent-test.js
+++ b/src/utils/__tests__/isStatelessComponent-test.js
@@ -66,6 +66,29 @@ describe('isStatelessComponent', () => {
     });
   });
 
+  describe('Stateless Function Components inside module pattern', () => {
+    it('', () => {
+      var def = parse(`
+        var Foo = {
+          Bar() { return <div />; },
+          Baz: function() { return React.createElement('div'); },
+          ['hello']: function() { return React.createElement('div'); },
+          render() { return 7; }
+        }
+      `).get('body', 0).get('declarations', 0).get('init');
+
+      var bar = def.get('properties', 0);
+      var baz = def.get('properties', 1);
+      var hello = def.get('properties', 2);
+      var render = def.get('properties', 3);
+
+      expect(isStatelessComponent(bar)).toBe(true);
+      expect(isStatelessComponent(baz)).toBe(true);
+      expect(isStatelessComponent(hello)).toBe(true);
+      expect(isStatelessComponent(render)).toBe(false);
+    });
+  });
+
   describe('is not overzealous', () => {
     it('does not accept declarations with a render method', () => {
       var def = statement(`

--- a/src/utils/__tests__/isStatelessComponent-test.js
+++ b/src/utils/__tests__/isStatelessComponent-test.js
@@ -45,23 +45,28 @@ describe('isStatelessComponent', () => {
 
   describe('Stateless Function Components with React.createElement', () => {
     it('accepts simple arrow function components', () => {
-      var def = parse(
-        'var Foo = () => React.creatElement("div", null);'
-      ).get('body', 0).get('declarations', [0]).get('init');
+      var def = parse(`
+        var AlphaBetters = require('react');
+        var Foo = () => AlphaBetters.createElement("div", null);
+      `).get('body', 1).get('declarations', [0]).get('init');
 
       expect(isStatelessComponent(def)).toBe(true);
     });
 
     it('accepts simple function expressions components', () => {
-      var def = parse(
-        'let Foo = function() { return React.createElement("div", null); };'
-      ).get('body', 0).get('declarations', [0]).get('init');
+      var def = parse(`
+        var React = require('react');
+        let Foo = function() { return React.createElement("div", null); };
+      `).get('body', 1).get('declarations', [0]).get('init');
 
       expect(isStatelessComponent(def)).toBe(true);
     });
 
     it('accepts simple function declaration components', () => {
-      var def = parse('function Foo () { return React.createElement("div", null); }').get('body', 0);
+      var def = parse(`
+        var React = require('react');
+        function Foo () { return React.createElement("div", null); }
+      `).get('body', 1);
       expect(isStatelessComponent(def)).toBe(true);
     });
   });
@@ -69,13 +74,14 @@ describe('isStatelessComponent', () => {
   describe('Stateless Function Components inside module pattern', () => {
     it('', () => {
       var def = parse(`
+        var React = require('react');
         var Foo = {
           Bar() { return <div />; },
           Baz: function() { return React.createElement('div'); },
           ['hello']: function() { return React.createElement('div'); },
           render() { return 7; }
         }
-      `).get('body', 0).get('declarations', 0).get('init');
+      `).get('body', 1).get('declarations', 0).get('init');
 
       var bar = def.get('properties', 0);
       var baz = def.get('properties', 1);
@@ -94,7 +100,7 @@ describe('isStatelessComponent', () => {
       var def = statement(`
         class Foo {
           render() {
-            return React.createElement('div', null);
+            return <div />;
           }
         }
       `);
@@ -124,7 +130,6 @@ describe('isStatelessComponent', () => {
       `);
       expect(isStatelessComponent(def)).toBe(false);
     });
-
   });
 });
 

--- a/src/utils/getMemberExpressionValuePath.js
+++ b/src/utils/getMemberExpressionValuePath.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ *
+ */
+
+import getNameOrValue from './getNameOrValue';
+import recast from 'recast';
+
+var {types: {namedTypes: types}} = recast;
+
+function resolveName(path) {
+  if (types.VariableDeclaration.check(path.node)) {
+    var declarations = path.get('declarations');
+    if (declarations.value.length && declarations.value.length !== 1) {
+      throw new TypeError(
+        'Got unsupported VariableDeclaration. VariableDeclaration must only ' + 
+        'have a single VariableDeclarator. Got ' + declarations.value.length +
+        ' declarations.'
+      );
+    }
+    var value = declarations.get(0, 'id', 'name').value;
+    return value;
+  }
+
+  if (types.FunctionDeclaration.check(path.node)) {
+    return path.get('id', 'name').value
+  }
+
+  if (types.FunctionExpression.check(path.node)) {
+    console.log('TODO: handle FunctionExpression');
+    // return path.get('id', 'name').value
+  }
+
+  throw new TypeError(
+    'Attempted to resolveName for an unsupported path. resolveName accepts a ' +
+    'VariableDeclaration, FunctionDeclaration, or FunctionExpression. Got "' +
+    path.node.type + '".'
+  );
+}
+
+function getRoot(node) {
+  var root = node.parent;
+  while (root.parent) {
+    root = root.parent;
+  }
+  return root;
+}
+
+export default function getMemberExpressionValuePath(
+  variableDefinition: NodePath,
+  memberName: string
+): ?NodePath {
+  if (typeof memberName === 'undefined') return;
+
+
+  var localName = resolveName(variableDefinition);
+  var program = getRoot(variableDefinition);
+
+  if (!localName) return;
+
+  var result;
+  recast.visit(program, {
+    visitAssignmentExpression(path) {
+      var memberPath = path.get('left');
+      if (!types.MemberExpression.check(memberPath.node)) {
+        return this.traverse(path);
+      }
+
+      if (
+        (!memberPath.node.computed || types.Literal.check(memberPath.node.property)) &&
+        getNameOrValue(memberPath.get('property')) === memberName
+      ) {
+        result = path.get('right');
+        return false;
+      }
+
+      this.traverse(memberPath);
+    },
+  });
+
+  return result;
+}

--- a/src/utils/getMemberValuePath.js
+++ b/src/utils/getMemberValuePath.js
@@ -23,6 +23,9 @@ var SYNONYMS = {
 };
 
 var LOOKUP_METHOD = {
+  [types.ArrowFunctionExpression.name]: getMemberExpressionValuePath,
+  [types.FunctionExpression.name]: getMemberExpressionValuePath,
+  [types.FunctionDeclaration.name]: getMemberExpressionValuePath,
   [types.VariableDeclaration.name]: getMemberExpressionValuePath,
   [types.ObjectExpression.name]: getPropertyValuePath,
   [types.ClassDeclaration.name]: getClassMemberValuePath,
@@ -33,7 +36,12 @@ function isSupportedDefinitionType({node}) {
   return types.ObjectExpression.check(node) ||
     types.ClassDeclaration.check(node) ||
     types.ClassExpression.check(node) ||
-    types.VariableDeclaration.check(node);
+
+    // potential stateless function component
+    types.VariableDeclaration.check(node) ||
+    types.ArrowFunctionExpression.check(node) ||
+    types.FunctionDeclaration.check(node) ||
+    types.FunctionExpression.check(node);
 }
 
 /**
@@ -55,10 +63,11 @@ export default function getMemberValuePath(
 ): ?NodePath {
   if (!isSupportedDefinitionType(componentDefinition)) {
     throw new TypeError(
-      'Got unsupported definition type. Definition must either be an ' +
-      'ObjectExpression, ClassDeclaration, ClassExpression, or a ' +
-      'VariableDeclaration. Got "' +
-      componentDefinition.node.type + '" instead.'
+      'Got unsupported definition type. Definition must be one of ' +
+      'ObjectExpression, ClassDeclaration, ClassExpression,' +
+      'VariableDeclaration, ArrowFunctionExpression, FunctionExpression, or ' +
+      'FunctionDeclaration. Got "' + componentDefinition.node.type + '"' +
+      'instead.'
     );
   }
 

--- a/src/utils/getMemberValuePath.js
+++ b/src/utils/getMemberValuePath.js
@@ -10,6 +10,7 @@
  *
  */
 
+import getMemberExpressionValuePath from './getMemberExpressionValuePath';
 import getClassMemberValuePath from './getClassMemberValuePath';
 import getPropertyValuePath from './getPropertyValuePath';
 import recast from 'recast';
@@ -22,6 +23,7 @@ var SYNONYMS = {
 };
 
 var LOOKUP_METHOD = {
+  [types.VariableDeclaration.name]: getMemberExpressionValuePath,
   [types.ObjectExpression.name]: getPropertyValuePath,
   [types.ClassDeclaration.name]: getClassMemberValuePath,
   [types.ClassExpression.name]: getClassMemberValuePath,
@@ -30,7 +32,8 @@ var LOOKUP_METHOD = {
 function isSupportedDefinitionType({node}) {
   return types.ObjectExpression.check(node) ||
     types.ClassDeclaration.check(node) ||
-    types.ClassExpression.check(node);
+    types.ClassExpression.check(node) ||
+    types.VariableDeclaration.check(node);
 }
 
 /**
@@ -53,7 +56,8 @@ export default function getMemberValuePath(
   if (!isSupportedDefinitionType(componentDefinition)) {
     throw new TypeError(
       'Got unsupported definition type. Definition must either be an ' +
-      'ObjectExpression, ClassDeclaration or ClassExpression. Got "' +
+      'ObjectExpression, ClassDeclaration, ClassExpression, or a ' +
+      'VariableDeclaration. Got "' +
       componentDefinition.node.type + '" instead.'
     );
   }

--- a/src/utils/isReactCreateElementCall.js
+++ b/src/utils/isReactCreateElementCall.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ *
+ */
+
+import isReactModuleName from './isReactModuleName';
+import match from './match';
+import recast from 'recast';
+import resolveToModule from './resolveToModule';
+
+var {types: {namedTypes: types}} = recast;
+
+/**
+ * Returns true if the expression is a function call of the form
+ * `React.createElement(...)`.
+ */
+export default function isReactCreateElementCall(path: NodePath): boolean {
+  if (types.ExpressionStatement.check(path.node)) {
+    path = path.get('expression');
+  }
+
+  if (!match(path.node, {callee: {property: {name: 'createElement'}}})) {
+    return false;
+  }
+  var module = resolveToModule(path.get('callee', 'object'));
+  return Boolean(module && isReactModuleName(module));
+}

--- a/src/utils/isStatelessComponent.js
+++ b/src/utils/isStatelessComponent.js
@@ -9,6 +9,7 @@
  * @flow
  */
 
+import getPropertyValuePath from './getPropertyValuePath';
 import isReactModuleName from './isReactModuleName';
 import isReactComponentClass from './isReactComponentClass';
 import isReactCreateClassCall from './isReactCreateClassCall';
@@ -26,7 +27,6 @@ const validPossibleStatelessComponentTypes = [
   'FunctionExpression',
   'ArrowFunctionExpression'
 ];
-
 
 function isJSXElementOrReactCreateElement(path) {
   return (
@@ -82,6 +82,20 @@ function returnsJSXElementOrReactCreateElementCall(path) {
         if (returnsJSXElementOrReactCreateElementCall(calleeValue)) {
           visited = true;
           return false;
+        }
+
+        if (calleeValue.node.type === 'MemberExpression') {
+          let resolvedValue = resolveToValue(calleeValue.get('object'));
+          if (types.ObjectExpression.check(resolvedValue.node)) {
+            var resolvedMemberExpression = getPropertyValuePath(
+              resolvedValue,
+              calleeValue.get('property').node.name
+            )
+            if (returnsJSXElementOrReactCreateElementCall(resolvedMemberExpression)) {
+              visited = true;
+              return false;
+            }
+          }
         }
       }
 

--- a/src/utils/isStatelessComponent.js
+++ b/src/utils/isStatelessComponent.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+import isReactModuleName from './isReactModuleName';
+import isReactComponentClass from './isReactComponentClass';
+import isReactCreateClassCall from './isReactCreateClassCall';
+import match from './match';
+import recast from 'recast';
+import resolveToModule from './resolveToModule';
+import resolveToValue from './resolveToValue';
+
+var {types: {namedTypes: types}} = recast;
+
+const validPossibleStatelessComponentTypes = [
+  'FunctionDeclaration',
+  'FunctionExpression',
+  // TODO: maybe include these variants for safety:
+  // https://github.com/benjamn/ast-types/blob/master/def/es6.js#L31
+  // https://github.com/estree/estree/issues/2
+  // 'ArrowExpression', 'ArrowFunction'
+  'ArrowFunctionExpression'
+];
+
+function containsJSXElementOrReactCreateElementCall(node) {
+  var visited = false;
+  recast.visit(node, {
+    visitJSXElement(path) {
+      visited = true;
+      this.traverse(path);
+    },
+
+    visitCallExpression(path) {
+      visited = true;
+      this.traverse(path);
+    }
+  })
+
+  return visited;
+}
+
+/**
+ * Returns `true` if the path represents a function which returns a JSXElment
+ */
+export default function isStatelessComponent(
+  path: NodePath
+): bool {
+  var node = path.node;
+
+  if (validPossibleStatelessComponentTypes.indexOf(node.type) === -1) {
+    return false;
+  }
+
+  if (containsJSXElementOrReactCreateElementCall(node)) {
+
+    return true;
+  }
+
+  return false;
+}
+
+

--- a/src/utils/isStatelessComponent.js
+++ b/src/utils/isStatelessComponent.js
@@ -68,9 +68,9 @@ function containsJSXElementOrReactCreateElementCall(path) {
 
   recast.visit(path, {
     visitReturnStatement(returnPath) {
-      var type = returnPath.get('argument').node.type;
+      var resolvedPath = resolveToValue(returnPath.get('argument'));
       if (
-        isJSXElementOrReactCreateElement(returnPath.get('argument')) &&
+        isJSXElementOrReactCreateElement(resolvedPath) &&
         isSameBlockScope(returnPath)
       ) {
         visited = true;

--- a/src/utils/isStatelessComponent.js
+++ b/src/utils/isStatelessComponent.js
@@ -20,6 +20,7 @@ import resolveToValue from './resolveToValue';
 var {types: {namedTypes: types}} = recast;
 
 const validPossibleStatelessComponentTypes = [
+  'Property',
   'FunctionDeclaration',
   'FunctionExpression',
   // TODO: maybe include these variants for safety:
@@ -56,6 +57,12 @@ export default function isStatelessComponent(
 
   if (validPossibleStatelessComponentTypes.indexOf(node.type) === -1) {
     return false;
+  }
+
+  if (node.type === 'Property') {
+    if (isReactCreateClassCall(path.parent) || isReactComponentClass(path.parent)) {
+      return false;
+    }
   }
 
   if (containsJSXElementOrReactCreateElementCall(node)) {

--- a/src/utils/isStatelessComponent.js
+++ b/src/utils/isStatelessComponent.js
@@ -12,6 +12,7 @@
 import isReactModuleName from './isReactModuleName';
 import isReactComponentClass from './isReactComponentClass';
 import isReactCreateClassCall from './isReactCreateClassCall';
+import isReactCreateElementCall from './isReactCreateElementCall';
 import match from './match';
 import recast from 'recast';
 import resolveToModule from './resolveToModule';
@@ -30,19 +31,23 @@ const validPossibleStatelessComponentTypes = [
   'ArrowFunctionExpression'
 ];
 
-function containsJSXElementOrReactCreateElementCall(node) {
+function containsJSXElementOrReactCreateElementCall(path) {
   var visited = false;
-  recast.visit(node, {
+  recast.visit(path, {
     visitJSXElement(path) {
       visited = true;
-      this.traverse(path);
+      return false;
     },
 
     visitCallExpression(path) {
-      visited = true;
+      if (isReactCreateElementCall(path)) {
+        visited = true;
+        return false;
+      }
+
       this.traverse(path);
     }
-  })
+  });
 
   return visited;
 }
@@ -65,8 +70,7 @@ export default function isStatelessComponent(
     }
   }
 
-  if (containsJSXElementOrReactCreateElementCall(node)) {
-
+  if (containsJSXElementOrReactCreateElementCall(path)) {
     return true;
   }
 

--- a/src/utils/isStatelessComponent.js
+++ b/src/utils/isStatelessComponent.js
@@ -88,7 +88,7 @@ function returnsJSXElementOrReactCreateElementCall(path) {
 
         let resolvedValue;
 
-        let namesToResolve = [calleeValue.get('property').node.name];
+        let namesToResolve = [calleeValue.get('property')];
 
         if (calleeValue.node.type === 'MemberExpression') {
           if (calleeValue.get('object').node.type === 'Identifier') {
@@ -97,7 +97,7 @@ function returnsJSXElementOrReactCreateElementCall(path) {
           else {
             while (calleeValue.get('object').node.type !== 'Identifier') {
               calleeValue = calleeValue.get('object');
-              namesToResolve.unshift(calleeValue.get('property').node.name);
+              namesToResolve.unshift(calleeValue.get('property'));
             };
 
             resolvedValue = resolveToValue(calleeValue.get('object'));
@@ -106,10 +106,13 @@ function returnsJSXElementOrReactCreateElementCall(path) {
 
         if (types.ObjectExpression.check(resolvedValue.node)) {
           var resolvedMemberExpression = namesToResolve
-            .reduce((result, name) =>
-              getPropertyValuePath(result, name),
-              resolvedValue
-            );
+            .reduce((result, path) => {
+              var result = getPropertyValuePath(result, path.node.name);
+              if (types.Identifier.check(result.node)) {
+                return resolveToValue(result);
+              }
+              return result;
+            }, resolvedValue);
 
           if (returnsJSXElementOrReactCreateElementCall(resolvedMemberExpression)) {
             visited = true;


### PR DESCRIPTION
Starts support for Stateless Component detection and documentation. Currently this adds an `isStatelessComponent` util method. I’ll start working on working this in to the resolvers now, but wanted early review on this to see if I missed anything.