### PR TITLE
[Browser] Fix babel output for the browser

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -52,10 +52,10 @@ function defaultParse( // eslint-disable-line no-unused-vars
   return parse(src, resolver, handlers);
 }
 
-export {
-  defaultParse as parse,
+export default {
+  parse: defaultParse,
   defaultHandlers,
   handlers,
   resolver,
-  utils
+  utils,
 };


### PR DESCRIPTION
I'm having the following code in my `/dist/main.js`
```js
exports.parse = defaultParse;
exports.defaultHandlers = defaultHandlers;
exports.handlers = handlers;
exports.resolver = resolver;
exports.utils = utils;
```
But I need
```js
module.exports = {
  parse: defaultParse,
  defaultHandlers: defaultHandlers,
  handlers: handlers,
  resolver: resolver,
  utils: utils,
};
```
To make this lib work on the browser.
I'm *assuming* this is the right way to fix the browser support.
I also had to submit this PR (https://github.com/benjamn/recast/pull/238) 