### PR TITLE
Support for flow types

### DIFF
--- a/flow/react-docgen.js
+++ b/flow/react-docgen.js
@@ -11,21 +11,43 @@
 import type Documentation from '../src/Documentation';
 
 type PropTypeDescriptor = {
-  name: string;
-  value?: any;
-  raw?: string;
-  computed?: boolean;
+  name: string,
+  value?: any,
+  raw?: string,
+  computed?: boolean,
   // These are only needed for shape types.
   // Consider consolidating PropTypeDescriptor and PropDescriptor
-  description?: string;
-  required?: boolean;
+  description?: string,
+  required?: boolean,
+};
+
+type flowObjectSignatureType = {
+  properties: Array<{ key: string | FlowTypeDescriptor, value: FlowTypeDescriptor }>,
+  constructor?: FlowTypeDescriptor
+};
+
+type flowFunctionSignatureType = {
+  arguments: Array<{ name: string, type: FlowTypeDescriptor }>,
+  return: FlowTypeDescriptor
+};
+
+type FlowTypeDescriptor = {
+  name: string,
+  value?: string,
+  required?: boolean,
+  nullable?: boolean,
+  raw?: string,
+  elements?: Array<FlowTypeDescriptor>,
+  type?: 'object' | 'function',
+  signature?: flowObjectSignatureType | flowFunctionSignatureType,
 };
 
 type PropDescriptor = {
-  type?: PropTypeDescriptor;
-  required?: boolean;
-  defaultValue?: any;
-  description?: string;
+  type?: PropTypeDescriptor,
+  flowType?: FlowTypeDescriptor,
+  required?: boolean,
+  defaultValue?: any,
+  description?: string,
 };
 
 type Handler = (documentation: Documentation, path: NodePath) => void;

--- a/flow/recast.js
+++ b/flow/recast.js
@@ -18,7 +18,9 @@ type ASTNode = Object;
 
 declare class Scope {
   lookup(name: string): ?Scope;
-  getBindings(): {[key: string]: NodePath};
+  lookupType(name: string): ?Scope;
+  getBindings(): {[key: string]: Array<NodePath>};
+  getTypes(): {[key: string]: Array<NodePath>};
   node: NodePath;
 }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babylon": "~5.8.3",
     "node-dir": "^0.1.10",
     "nomnom": "^1.8.1",
-    "recast": "^0.10.33"
+    "recast": "^0.10.41"
   },
   "devDependencies": {
     "babel": "^5.6.23",

--- a/src/handlers/__tests__/flowTypeDocBlockHandler-test.js
+++ b/src/handlers/__tests__/flowTypeDocBlockHandler-test.js
@@ -1,0 +1,178 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+/*global jest, describe, it, expect, beforeEach*/
+
+jest.autoMockOff();
+jest.mock('../../Documentation');
+
+describe('flowTypeDocBlockHandler', () => {
+  var statement, expression;
+  var getFlowTypeMock;
+  var documentation;
+  var flowTypeDocBlockHandler;
+
+  beforeEach(() => {
+    ({statement, expression} = require('../../../tests/utils'));
+    getFlowTypeMock = jest.genMockFunction().mockImplementation(() => ({}));
+    jest.setMock('../../utils/getFlowType', getFlowTypeMock);
+    jest.mock('../../utils/getFlowType');
+
+    documentation = new (require('../../Documentation'));
+    flowTypeDocBlockHandler = require('../flowTypeDocBlockHandler');
+  });
+
+  function template(src, typeObject) {
+    return `
+      ${src}
+      var React = require('React');
+      var Component = React.Component;
+
+      type Props = ${typeObject};
+    `;
+  }
+
+  function test(getSrc) {
+    it('detects description correctly', () => {
+      var flowTypesSrc = `
+      {
+        /** my description */
+        foo: string,
+        /** my description 2 */
+        bar: number,
+
+        /**
+         * my description 3
+         */
+
+        hal: boolean,
+      }
+      `;
+      var definition = getSrc(flowTypesSrc);
+
+      flowTypeDocBlockHandler(documentation, definition);
+
+      expect(documentation.descriptors).toEqual({
+        foo: {
+          description: 'my description',
+        },
+        bar: {
+          description: 'my description 2',
+        },
+        hal: {
+          description: 'my description 3',
+        },
+      });
+    });
+
+
+    it('does not update description if already set', () => {
+      var flowTypesSrc = `
+      {
+        /** my description */
+        foo: string,
+      }
+      `;
+      var definition = getSrc(flowTypesSrc);
+      documentation.getPropDescriptor('foo').description = '12345678';
+
+      flowTypeDocBlockHandler(documentation, definition);
+
+      expect(documentation.descriptors).toEqual({
+        foo: {
+          description: '12345678',
+        },
+      });
+    });
+  }
+
+  describe('TypeAlias', () => {
+    describe('class definition', () => {
+      test(
+        propTypesSrc => statement(template(`class Foo extends Component<void, Props, void> {}`, propTypesSrc))
+      );
+    });
+
+    describe('class definition with inline props', () => {
+      test(
+          propTypesSrc => statement(template(`class Foo extends Component { props: Props; }`, propTypesSrc))
+      );
+    });
+
+    describe('stateless component', () => {
+      test(
+        propTypesSrc => statement(template(`(props: Props) => <div />;`, propTypesSrc)).get('expression')
+      );
+    });
+  });
+
+  it('does not error if flowTypes cannot be found', () => {
+    var definition = expression('{fooBar: 42}');
+    expect(() => flowTypeDocBlockHandler(documentation, definition))
+      .not.toThrow();
+
+    definition = statement('class Foo extends Component {}');
+    expect(() => flowTypeDocBlockHandler(documentation, definition))
+      .not.toThrow();
+
+    definition = statement('() => <div />');
+    expect(() => flowTypeDocBlockHandler(documentation, definition))
+      .not.toThrow();
+  });
+
+  describe('does not error for unreachable type', () => {
+    function test(code) {
+      var definition = statement(code).get('expression');
+
+      expect(() => flowTypeDocBlockHandler(documentation, definition))
+        .not.toThrow();
+
+      expect(documentation.descriptors).toEqual({});
+    }
+
+    it('required', () => {
+      test(`
+        (props: Props) => <div />;
+        var React = require('React');
+        var Component = React.Component;
+
+        var Props = require('something');
+      `);
+    });
+
+    it('imported', () => {
+      test(`
+        (props: Props) => <div />;
+        var React = require('React');
+        var Component = React.Component;
+
+        import Props from 'something';
+      `);
+    });
+
+    it('type imported', () => {
+      test(`
+        (props: Props) => <div />;
+        var React = require('React');
+        var Component = React.Component;
+
+        import type Props from 'something';
+      `);
+    });
+
+    it('not in scope', () => {
+      test(`
+        (props: Props) => <div />;
+        var React = require('React');
+        var Component = React.Component;
+      `);
+    });
+  });
+});

--- a/src/handlers/__tests__/flowTypeHandler-test.js
+++ b/src/handlers/__tests__/flowTypeHandler-test.js
@@ -1,0 +1,218 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+/*global jest, describe, it, expect, beforeEach*/
+
+jest.autoMockOff();
+jest.mock('../../Documentation');
+
+describe('flowTypeHandler', () => {
+  var statement, expression;
+  var getFlowTypeMock;
+  var documentation;
+  var flowTypeHandler;
+
+  beforeEach(() => {
+    ({statement, expression} = require('../../../tests/utils'));
+    getFlowTypeMock = jest.genMockFunction().mockImplementation(() => ({}));
+    jest.setMock('../../utils/getFlowType', getFlowTypeMock);
+    jest.mock('../../utils/getFlowType');
+
+    documentation = new (require('../../Documentation'));
+    flowTypeHandler = require('../flowTypeHandler');
+  });
+
+  function template(src, typeObject) {
+    return `
+      ${src}
+      var React = require('React');
+      var Component = React.Component;
+
+      type Props = ${typeObject};
+    `;
+  }
+
+  function test(getSrc) {
+    it('detects types correctly', () => {
+      var flowTypesSrc = `
+      {
+        foo: string,
+        bar: number,
+        hal: boolean,
+      }
+      `;
+      var definition = getSrc(flowTypesSrc);
+
+      flowTypeHandler(documentation, definition);
+
+      expect(documentation.descriptors).toEqual({
+        foo: {
+          flowType: {},
+          required: true,
+        },
+        bar: {
+          flowType: {},
+          required: true,
+        },
+        hal: {
+          flowType: {},
+          required: true,
+        },
+        });
+    });
+
+    it('detects whether a prop is required', () => {
+      var flowTypesSrc = `
+      {
+        foo: string,
+        bar?: number,
+      }
+      `;
+      var definition = getSrc(flowTypesSrc);
+
+      flowTypeHandler(documentation, definition);
+
+      expect(documentation.descriptors).toEqual({
+        foo: {
+          flowType: {},
+          required: true,
+        },
+        bar: {
+          flowType: {},
+          required: false,
+        },
+      });
+    });
+
+    it('detects union types', () => {
+      var flowTypesSrc = `
+      {
+        foo: string | number,
+        bar: "test" | 1 | true,
+      }
+      `;
+      var definition = getSrc(flowTypesSrc);
+
+      flowTypeHandler(documentation, definition);
+
+      expect(documentation.descriptors).toEqual({
+        foo: {
+          flowType: {},
+          required: true,
+        },
+        bar: {
+          flowType: {},
+          required: true,
+        },
+      });
+    });
+
+    it('detects intersection types', () => {
+      var flowTypesSrc = `
+      {
+        foo: Foo & Bar,
+      }
+      `;
+      var definition = getSrc(flowTypesSrc);
+
+      flowTypeHandler(documentation, definition);
+
+      expect(documentation.descriptors).toEqual({
+        foo: {
+          flowType: {},
+          required: true,
+        },
+      });
+    });
+  }
+
+  describe('TypeAlias', () => {
+    describe('class definition', () => {
+      test(
+        propTypesSrc => statement(template(`class Foo extends Component<void, Props, void> {}`, propTypesSrc))
+      );
+    });
+
+    describe('class definition with inline props', () => {
+      test(
+          propTypesSrc => statement(template(`class Foo extends Component { props: Props; }`, propTypesSrc))
+      );
+    });
+
+    describe('stateless component', () => {
+      test(
+        propTypesSrc => statement(template(`(props: Props) => <div />;`, propTypesSrc)).get('expression')
+      );
+    });
+  });
+
+  it('does not error if flowTypes cannot be found', () => {
+    var definition = expression('{fooBar: 42}');
+    expect(() => flowTypeHandler(documentation, definition))
+      .not.toThrow();
+
+    definition = statement('class Foo extends Component {}');
+    expect(() => flowTypeHandler(documentation, definition))
+      .not.toThrow();
+
+    definition = statement('() => <div />');
+    expect(() => flowTypeHandler(documentation, definition))
+      .not.toThrow();
+  });
+
+  describe('does not error for unreachable type', () => {
+    function test(code) {
+      var definition = statement(code).get('expression');
+
+      expect(() => flowTypeHandler(documentation, definition))
+        .not.toThrow();
+
+      expect(documentation.descriptors).toEqual({});
+    }
+
+    it('required', () => {
+      test(`
+        (props: Props) => <div />;
+        var React = require('React');
+        var Component = React.Component;
+
+        var Props = require('something');
+      `);
+    });
+
+    it('imported', () => {
+      test(`
+        (props: Props) => <div />;
+        var React = require('React');
+        var Component = React.Component;
+
+        import Props from 'something';
+      `);
+    });
+
+    it('type imported', () => {
+      test(`
+        (props: Props) => <div />;
+        var React = require('React');
+        var Component = React.Component;
+
+        import type Props from 'something';
+      `);
+    });
+
+    it('not in scope', () => {
+      test(`
+        (props: Props) => <div />;
+        var React = require('React');
+        var Component = React.Component;
+      `);
+    });
+  });
+});

--- a/src/handlers/flowTypeDocBlockHandler.js
+++ b/src/handlers/flowTypeDocBlockHandler.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ *
+ */
+
+import type Documentation from '../Documentation';
+import setPropDescription from '../utils/setPropDescription';
+import getFlowTypeFromReactComponent from '../utils/getFlowTypeFromReactComponent';
+
+/**
+ * This handler tries to find flow Type annotated react components and extract
+ * its types to the documentation. It also extracts docblock comments which are
+ * inlined in the type definition.
+ */
+export default function flowTypeDocBlockHandler(documentation: Documentation, path: NodePath) {
+  let flowTypesPath = getFlowTypeFromReactComponent(path);
+
+  if (!flowTypesPath) {
+    return;
+  }
+
+  flowTypesPath.get('properties').each(propertyPath => setPropDescription(documentation, propertyPath));
+}

--- a/src/handlers/flowTypeHandler.js
+++ b/src/handlers/flowTypeHandler.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ *
+ */
+
+import type Documentation from '../Documentation';
+
+import getFlowType from '../utils/getFlowType';
+import getPropertyName from '../utils/getPropertyName';
+import getFlowTypeFromReactComponent from '../utils/getFlowTypeFromReactComponent';
+
+/**
+ * This handler tries to find flow Type annotated react components and extract
+ * its types to the documentation. It also extracts docblock comments which are
+ * inlined in the type definition.
+ */
+export default function flowTypeHandler(documentation: Documentation, path: NodePath) {
+  let flowTypesPath = getFlowTypeFromReactComponent(path);
+
+  if (!flowTypesPath) {
+    return;
+  }
+
+  flowTypesPath.get('properties').each(propertyPath => {
+    const propDescriptor = documentation.getPropDescriptor(
+      getPropertyName(propertyPath)
+    );
+    const valuePath = propertyPath.get('value');
+    const type = getFlowType(valuePath);
+
+    if (type) {
+      propDescriptor.flowType = type;
+      propDescriptor.required = !propertyPath.node.optional;
+    }
+  });
+}

--- a/src/handlers/index.js
+++ b/src/handlers/index.js
@@ -17,3 +17,5 @@ export {default as propTypeHandler} from './propTypeHandler';
 export {default as propTypeCompositionHandler} from './propTypeCompositionHandler';
 export {default as propDocBlockHandler} from './propDocBlockHandler';
 export {default as displayNameHandler} from './displayNameHandler';
+export {default as flowTypeHandler} from './flowTypeHandler';
+export {default as flowTypeDocBlockHandler} from './flowTypeDocBlockHandler';

--- a/src/handlers/propDocBlockHandler.js
+++ b/src/handlers/propDocBlockHandler.js
@@ -12,11 +12,10 @@
 
 import type Documentation from '../Documentation';
 
-import {getDocblock} from '../utils/docblock';
-import getPropertyName from '../utils/getPropertyName';
 import getMemberValuePath from '../utils/getMemberValuePath';
 import recast from 'recast';
 import resolveToValue from '../utils/resolveToValue';
+import setPropDescription from '../utils/setPropDescription';
 
 var {types: {namedTypes: types}} = recast;
 
@@ -33,13 +32,10 @@ export default function propDocBlockHandler(
     return;
   }
 
-  propTypesPath.get('properties').each(function(propertyPath) {
+  propTypesPath.get('properties').each(propertyPath => {
     // we only support documentation of actual properties, not spread
     if (types.Property.check(propertyPath.node)) {
-      var propDescriptor = documentation.getPropDescriptor(
-        getPropertyName(propertyPath)
-      );
-      propDescriptor.description = getDocblock(propertyPath) || '';
+      setPropDescription(documentation, propertyPath);
     }
   });
 }

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,8 @@ var defaultHandlers = [
   handlers.propTypeHandler,
   handlers.propTypeCompositionHandler,
   handlers.propDocBlockHandler,
+  handlers.flowTypeHandler,
+  handlers.flowTypeDocBlockHandler,
   handlers.defaultPropsHandler,
   handlers.componentDocblockHandler,
   handlers.displayNameHandler,
@@ -57,5 +59,5 @@ export {
   defaultHandlers,
   handlers,
   resolver,
-  utils
+  utils,
 };

--- a/src/resolver/index.js
+++ b/src/resolver/index.js
@@ -15,5 +15,5 @@ import findExportedComponentDefinition from './findExportedComponentDefinition';
 
 export {
   findAllComponentDefinitions,
-  findExportedComponentDefinition
+  findExportedComponentDefinition,
 };

--- a/src/utils/__tests__/getFlowType-test.js
+++ b/src/utils/__tests__/getFlowType-test.js
@@ -1,0 +1,198 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+/*global jest, describe, beforeEach, it, expect*/
+
+jest.autoMockOff();
+
+describe('getFlowType', () => {
+  var expression, statement;
+  var getFlowType;
+
+  beforeEach(() => {
+    getFlowType = require('../getFlowType');
+    ({expression, statement} = require('../../../tests/utils'));
+  });
+
+  it('detects simple types', () => {
+    var simplePropTypes = [
+      'string',
+      'number',
+      'boolean',
+      'any',
+      'mixed',
+      'void',
+      'Object',
+      'Function',
+      'Boolean',
+      'String',
+      'Number',
+    ];
+
+    simplePropTypes.forEach(
+      type => {
+        var typePath = expression('x: ' + type).get('typeAnnotation').get('typeAnnotation');
+        expect(getFlowType(typePath)).toEqual({ name: type });
+      }
+    );
+  });
+
+  it('detects literal types', () => {
+    var literalTypes = [
+      '"foo"',
+      1234,
+      true,
+    ];
+
+    literalTypes.forEach(
+      value => {
+        var typePath = expression(`x: ${value}`).get('typeAnnotation').get('typeAnnotation');
+        expect(getFlowType(typePath)).toEqual({ name: 'literal', value: `${value}` });
+      }
+    );
+  });
+
+  it('detects external type', () => {
+    var typePath = expression('x: xyz').get('typeAnnotation').get('typeAnnotation');
+    expect(getFlowType(typePath)).toEqual({ name: 'xyz' });
+  });
+  it('detects external nullable type', () => {
+    var typePath = expression('x: ?xyz').get('typeAnnotation').get('typeAnnotation');
+    expect(getFlowType(typePath)).toEqual({ name: 'xyz', nullable: true });
+  });
+
+  it('detects array type', () => {
+    var typePath = expression('x: Array<number>').get('typeAnnotation').get('typeAnnotation');
+    expect(getFlowType(typePath)).toEqual({ name: 'Array', elements: [{ name: 'number' }], raw: 'Array<number>' });
+  });
+
+  it('detects array type with multiple types', () => {
+    var typePath = expression('x: Array<number, xyz>').get('typeAnnotation').get('typeAnnotation');
+    expect(getFlowType(typePath)).toEqual({ name: 'Array', elements: [{ name: 'number' }, { name: 'xyz' }], raw: 'Array<number, xyz>' });
+  });
+
+  it('detects class type', () => {
+    var typePath = expression('x: Class<Boolean>').get('typeAnnotation').get('typeAnnotation');
+    expect(getFlowType(typePath)).toEqual({ name: 'Class', elements: [{ name: 'Boolean' }], raw: 'Class<Boolean>' });
+  });
+
+  it('detects function type with subtype', () => {
+    var typePath = expression('x: Function<xyz>').get('typeAnnotation').get('typeAnnotation');
+    expect(getFlowType(typePath)).toEqual({name: 'Function', elements: [{ name: 'xyz' }], raw: 'Function<xyz>' });
+  });
+
+  it('detects object types', () => {
+    var typePath = expression('x: { a: string, b?: xyz }').get('typeAnnotation').get('typeAnnotation');
+    expect(getFlowType(typePath)).toEqual({name: 'signature', type: 'object', signature: {
+      properties: [
+        { key: 'a', value: { name: 'string', required: true } },
+        { key: 'b', value: { name: 'xyz', required: false } },
+      ],
+    }, raw: '{ a: string, b?: xyz }'});
+  });
+
+  it('detects object types with maybe type', () => {
+    var typePath = expression('x: { a: string, b: ?xyz }').get('typeAnnotation').get('typeAnnotation');
+    expect(getFlowType(typePath)).toEqual({name: 'signature', type: 'object', signature: {
+      properties: [
+        { key: 'a', value: { name: 'string', required: true } },
+        { key: 'b', value: { name: 'xyz', nullable: true, required: true } },
+      ],
+    }, raw: '{ a: string, b: ?xyz }'});
+  });
+
+  it('detects union type', () => {
+    var typePath = expression('x: string | xyz | "foo" | void').get('typeAnnotation').get('typeAnnotation');
+    expect(getFlowType(typePath)).toEqual({name: 'union', elements: [
+      { name: 'string' },
+      { name: 'xyz' },
+      { name: 'literal', value: '"foo"' },
+      { name: 'void' },
+    ], raw: 'string | xyz | "foo" | void'});
+  });
+
+  it('detects intersection type', () => {
+    var typePath = expression('x: string & xyz & "foo" & void').get('typeAnnotation').get('typeAnnotation');
+    expect(getFlowType(typePath)).toEqual({name: 'intersection', elements: [
+      { name: 'string' },
+      { name: 'xyz' },
+      { name: 'literal', value: '"foo"' },
+      { name: 'void' },
+    ], raw: 'string & xyz & "foo" & void'});
+  });
+
+  it('detects function signature type', () => {
+    var typePath = expression('x: (p1: number, p2: ?string) => boolean').get('typeAnnotation').get('typeAnnotation');
+    expect(getFlowType(typePath)).toEqual({name: 'signature', type: 'function', signature: {
+      arguments: [
+        { name: 'p1', type: { name: 'number' }},
+        { name: 'p2', type: { name: 'string', nullable: true }},
+      ],
+      return: { name: 'boolean' },
+    }, raw: '(p1: number, p2: ?string) => boolean'});
+  });
+
+  it('detects callable signature type', () => {
+    var typePath = expression('x: { (str: string): string, token: string }').get('typeAnnotation').get('typeAnnotation');
+    expect(getFlowType(typePath)).toEqual({name: 'signature', type: 'object', signature: {
+      constructor: {
+        name: 'signature',
+        type: 'function',
+        signature: {
+          arguments: [
+            { name: 'str', type: { name: 'string' } },
+          ],
+          return: { name: 'string' },
+        },
+        raw: '(str: string): string',
+      },
+      properties: [
+        { key: 'token', value: { name: 'string', required: true } },
+      ],
+    }, raw: '{ (str: string): string, token: string }'});
+  });
+
+  it('detects map signature', () => {
+    var typePath = expression('x: { [key: string]: number, [key: "xl"]: string, token: "a" | "b" }').get('typeAnnotation').get('typeAnnotation');
+    expect(getFlowType(typePath)).toEqual({name: 'signature', type: 'object', signature: {
+      properties: [
+        { key: { name: 'string' }, value: { name: 'number', required: true } },
+        { key: { name: 'literal', value: '"xl"' }, value: { name: 'string', required: true } },
+        { key: 'token', value: { name: 'union', required: true, raw: '"a" | "b"', elements: [ { name: 'literal', value: '"a"' }, { name: 'literal', value: '"b"' } ] } },
+      ],
+    }, raw: '{ [key: string]: number, [key: "xl"]: string, token: "a" | "b" }'});
+  });
+
+  it('detects tuple signature', () => {
+    var typePath = expression('x: [string, number]').get('typeAnnotation').get('typeAnnotation');
+    expect(getFlowType(typePath)).toEqual({name: 'tuple', elements: [
+      { name: 'string' },
+      { name: 'number' },
+    ], raw: '[string, number]'});
+  });
+
+  it('detects tuple in union signature', () => {
+    var typePath = expression('x: [string, number] | [number, string]').get('typeAnnotation').get('typeAnnotation');
+    expect(getFlowType(typePath)).toEqual({name: 'union', elements: [
+      { name: 'tuple', elements: [ { name: 'string' }, { name: 'number' }], raw: '[string, number]' },
+      { name: 'tuple', elements: [ { name: 'number' }, { name: 'string' }], raw: '[number, string]' },
+    ], raw: '[string, number] | [number, string]'});
+  });
+
+  it('resolves types in scope', () => {
+    var typePath = statement(`
+      var x: MyType = 2;
+
+      type MyType = string;
+    `).get('declarations', 0).get('id').get('typeAnnotation').get('typeAnnotation');
+
+    expect(getFlowType(typePath)).toEqual({ name: 'string' });
+  });
+});

--- a/src/utils/__tests__/getTypeAnnotation-test.js
+++ b/src/utils/__tests__/getTypeAnnotation-test.js
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+/*global jest, describe, beforeEach, it, expect*/
+
+jest.autoMockOff();
+
+describe('getTypeAnnotation', () => {
+  var expression, statement;
+  var getTypeAnnotation;
+
+  beforeEach(() => {
+    getTypeAnnotation = require('../getTypeAnnotation');
+    ({expression, statement} = require('../../../tests/utils'));
+  });
+
+  it('detects simple type', () => {
+    var path = expression('x: xyz');
+
+    expect(getTypeAnnotation(path)).toEqual(path.get('typeAnnotation').get('typeAnnotation'));
+  });
+
+  it('does not fail if no type', () => {
+    var path = expression('x = 0');
+
+    expect(getTypeAnnotation(path)).toEqual(null);
+  });
+
+  it('stops at first nested type', () => {
+    var path = expression('x: ?xyz');
+
+    expect(getTypeAnnotation(path)).toEqual(path.get('typeAnnotation').get('typeAnnotation'));
+  });
+
+});

--- a/src/utils/getFlowType.js
+++ b/src/utils/getFlowType.js
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ *
+ */
+
+/* eslint no-use-before-define: 0 */
+
+import getPropertyName from './getPropertyName';
+import printValue from './printValue';
+import recast from 'recast';
+import getTypeAnnotation from '../utils/getTypeAnnotation';
+import resolveToValue from '../utils/resolveToValue';
+import isUnreachableFlowType from '../utils/isUnreachableFlowType';
+
+const { types: { namedTypes: types } } = recast;
+
+const flowTypes = {
+  AnyTypeAnnotation: 'any',
+  BooleanTypeAnnotation: 'boolean',
+  MixedTypeAnnotation: 'mixed',
+  NumberTypeAnnotation: 'number',
+  StringTypeAnnotation: 'string',
+  VoidTypeAnnotation: 'void',
+};
+
+const flowLiteralTypes = {
+  BooleanLiteralTypeAnnotation: 1,
+  NumberLiteralTypeAnnotation: 1,
+  StringLiteralTypeAnnotation: 1,
+};
+
+const namedTypes = {
+  GenericTypeAnnotation: handleGenericTypeAnnotation,
+  ObjectTypeAnnotation: handleObjectTypeAnnotation,
+  UnionTypeAnnotation: handleUnionTypeAnnotation,
+  NullableTypeAnnotation: handleNullableTypeAnnotation,
+  FunctionTypeAnnotation: handleFunctionTypeAnnotation,
+  IntersectionTypeAnnotation: handleIntersectionTypeAnnotation,
+  TupleTypeAnnotation: handleTupleTypeAnnotation,
+};
+
+function getFlowTypeWithRequirements(path: NodePath): FlowTypeDescriptor {
+  const type = getFlowType(path);
+
+  type.required = !path.parentPath.node.optional;
+
+  return type;
+}
+
+function handleGenericTypeAnnotation(path: NodePath) {
+  let type = { name: path.node.id.name };
+
+  if (path.node.typeParameters) {
+    const params = path.get('typeParameters').get('params');
+
+    type = {
+      ...type,
+      elements: params.map(param => getFlowType(param)),
+      raw: printValue(path),
+    };
+  } else {
+    let resolvedPath = resolveToValue(path.get('id'));
+
+    if (!isUnreachableFlowType(resolvedPath)) {
+      type = getFlowType(resolvedPath.get('right'));
+    }
+  }
+
+  return type;
+}
+
+function handleObjectTypeAnnotation(path: NodePath) {
+  const type = {
+    name: 'signature',
+    type: 'object',
+    raw: printValue(path),
+    signature: { properties: [] },
+  };
+
+  path.get('callProperties').each(param => {
+    type.signature.constructor = getFlowType(param.get('value'));
+  });
+
+  path.get('indexers').each(param => {
+    type.signature.properties.push({
+      key: getFlowType(param.get('key')),
+      value: getFlowTypeWithRequirements(param.get('value')),
+    });
+  });
+
+  path.get('properties').each(param => {
+    type.signature.properties.push({
+        key: getPropertyName(param),
+        value: getFlowTypeWithRequirements(param.get('value')),
+    });
+  });
+
+  return type;
+}
+
+function handleUnionTypeAnnotation(path: NodePath) {
+  return {
+    name: 'union',
+    raw: printValue(path),
+    elements: path.get('types').map(subType => getFlowType(subType)),
+  };
+}
+
+function handleIntersectionTypeAnnotation(path: NodePath) {
+  return {
+    name: 'intersection',
+    raw: printValue(path),
+    elements: path.get('types').map(subType => getFlowType(subType)),
+  };
+}
+
+function handleNullableTypeAnnotation(path: NodePath) {
+  const typeAnnotation = getTypeAnnotation(path);
+
+  if (!typeAnnotation) return null;
+
+  const type = getFlowType(typeAnnotation);
+  type.nullable = true;
+
+  return type;
+}
+
+function handleFunctionTypeAnnotation(path: NodePath) {
+  const type = {
+    name: 'signature',
+    type: 'function',
+    raw: printValue(path),
+    signature: {
+      arguments: [],
+      return: getFlowType(path.get('returnType')),
+    },
+  };
+
+  path.get('params').each(param => {
+    const typeAnnotation = getTypeAnnotation(param);
+    if (!typeAnnotation) return null;
+
+    type.signature.arguments.push({
+      name: getPropertyName(param.get('name')),
+      type: getFlowType(typeAnnotation),
+    });
+  });
+
+  return type;
+}
+
+function handleTupleTypeAnnotation(path: NodePath) {
+  const type = { name: 'tuple', raw: printValue(path), elements: [] };
+
+  path.get('types').each(param => {
+    type.elements.push(getFlowType(param));
+  });
+
+  return type;
+}
+
+/**
+ * Tries to identify the flow type by inspecting the path for known
+ * flow type names. This method doesn't check whether the found type is actually
+ * existing. It simply assumes that a match is always valid.
+ *
+ * If there is no match, "unknown" is returned.
+ */
+export default function getFlowType(path: NodePath): FlowTypeDescriptor {
+  const node = path.node;
+  let type: ?FlowTypeDescriptor;
+
+  if (types.Type.check(node)) {
+    if (node.type in flowTypes) {
+      type = { name: flowTypes[node.type] };
+    } else if (node.type in flowLiteralTypes) {
+      type = { name: 'literal', value: node.raw || `${node.value}` };
+    } else if (node.type in namedTypes) {
+      type = namedTypes[node.type](path);
+    }
+  }
+
+  if (!type) {
+    type = { name: 'unknown' };
+  }
+
+  return type;
+}

--- a/src/utils/getFlowTypeFromReactComponent.js
+++ b/src/utils/getFlowTypeFromReactComponent.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ *
+ */
+
+import getPropertyName from './getPropertyName';
+import getTypeAnnotation from '../utils/getTypeAnnotation';
+import getMemberValuePath from '../utils/getMemberValuePath';
+import isReactComponentClass from '../utils/isReactComponentClass';
+import isStatelessComponent from '../utils/isStatelessComponent';
+import isUnreachableFlowType from '../utils/isUnreachableFlowType';
+import recast from 'recast';
+import resolveToValue from '../utils/resolveToValue';
+
+var {types: {namedTypes: types}} = recast;
+
+/**
+ * Given an React component (stateless or class) tries to find the
+ * flow type for the props. If not found or not one of the supported
+ * component types returns null.
+ */
+export default (path: NodePath): ?NodePath  => {
+  let typePath: ?NodePath;
+
+  if (isReactComponentClass(path)) {
+    const superTypes = path.get('superTypeParameters');
+
+    if (superTypes.value) {
+      typePath = superTypes.get('params').get(1);
+    } else {
+      const propsMemberPath = getMemberValuePath(path, 'props');
+      if (!propsMemberPath) {
+        return null;
+      }
+
+      typePath = getTypeAnnotation(propsMemberPath.parentPath);
+    }
+  } else if (isStatelessComponent(path)) {
+    const param = path.get('params').get(0);
+
+    typePath = getTypeAnnotation(param);
+  }
+
+  if (typePath && types.GenericTypeAnnotation.check(typePath.node)) {
+    typePath = resolveToValue(typePath.get('id'));
+    if (
+      !typePath || 
+      types.Identifier.check(typePath.node) ||
+      isUnreachableFlowType(typePath)
+    ) {
+      return;
+    }
+
+    typePath = typePath.get('right');
+  }
+
+  return typePath;
+}

--- a/src/utils/getTypeAnnotation.js
+++ b/src/utils/getTypeAnnotation.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ *
+ */
+
+import recast from 'recast';
+const { types: { namedTypes: types } } = recast;
+
+function hasTypeAnnotation(path: NodePath): boolean {
+  return !!path.node.typeAnnotation;
+}
+
+/**
+ * Gets the most inner valuable TypeAnnotation from path. If no TypeAnnotation
+ * can be found nothing is returned
+ */
+export default function getTypeAnnotation(path: NodePath): ?NodePath {
+  if (!hasTypeAnnotation(path)) return null;
+
+  let resultPath: NodePath = path;
+  do {
+    resultPath = resultPath.get('typeAnnotation');
+  } while (hasTypeAnnotation(resultPath) && !types.Type.check(resultPath.node));
+
+  return resultPath;
+}

--- a/src/utils/isRequiredPropType.js
+++ b/src/utils/isRequiredPropType.js
@@ -1,9 +1,20 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
 import getMembers from '../utils/getMembers';
 
 /**
  * Returns true of the prop is required, according to its type defintion
  */
-export default function isRequiredPropType(path) {
+export default function isRequiredPropType(path: NodePath): boolean {
   return getMembers(path).some(
     member => !member.computed && member.path.node.name === 'isRequired' ||
       member.computed && member.path.node.value === 'isRequired'

--- a/src/utils/isStatelessComponent.js
+++ b/src/utils/isStatelessComponent.js
@@ -128,7 +128,7 @@ function returnsJSXElementOrReactCreateElementCall(path) {
 }
 
 /**
- * Returns `true` if the path represents a function which returns a JSXElment
+ * Returns `true` if the path represents a function which returns a JSXElement
  */
 export default function isStatelessComponent(
   path: NodePath

--- a/src/utils/isUnreachableFlowType.js
+++ b/src/utils/isUnreachableFlowType.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+import recast from 'recast';
+
+const { types: { namedTypes: types } } = recast;
+
+/**
+ * Returns true of the path is an unreachable TypePath
+ */
+export default (path: NodePath): boolean => {
+  return !path ||
+    types.Identifier.check(path.node) ||
+    types.ImportDeclaration.check(path.node) ||
+    types.CallExpression.check(path.node);
+}

--- a/src/utils/setPropDescription.js
+++ b/src/utils/setPropDescription.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ *
+ */
+
+import type Documentation from '../Documentation';
+import getPropertyName from './getPropertyName';
+import { getDocblock } from './docblock';
+
+/**
+ *
+ */
+export default (documentation: Documentation, propertyPath: NodePath) => {
+  const propName = getPropertyName(propertyPath);
+  const propDescriptor = documentation.getPropDescriptor(propName);
+
+  if (propDescriptor.description) {
+    return;
+  }
+
+  propDescriptor.description = getDocblock(propertyPath) || '';
+}


### PR DESCRIPTION
I started working on adding support for flow types.

So far I only tried to get it working for classes, and it already works nicely for this usecase, but only for string type and declared types. The code although is far away from nice yet. It also needs a patched version of ast-types, which I will create a PR also soon.

I opened this PR already so that interested people can join and already have a look and maybe give feedback.

Will fix #31

This needs to be done:

- [x] support es6 classes
- [x] ~~support createClass()~~
- [x] support stateless components()
- [x] support all types from flow
  - [x] primitive types
  - [x] class types
  - [x] object signature
  - [x] literal types
  - [x] function signature
  - [x] callable-object/function-object signature
  - [x] maybe types
  - [x] union
  - [x] intersection
- [x] support inline type definitions
- [x] support declared type definitions
- [x] extract description from type
- [x] ~~handle imported type definitions (not really sure if we can do anything about that)~~
- [x] add tests
- [x] update ast-types to support Identifiers to TypeAlias
- [x] make code clean :)
- [x] adapt Readme