### PR TITLE
Do not compile tests and mocks to dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "dist/main.js",
   "scripts": {
     "watch": "babel src/ --out-dir dist/ --watch",
-    "build": "rm -rf dist/ && babel src/ --out-dir dist/",
+    "build": "rm -rf dist/ && babel src/ --out-dir dist/ --ignore __tests__,__mocks__",
     "prepublish": "npm run build",
     "test": "jest"
   },


### PR DESCRIPTION
To run the tests it is not needed to transpile them beforehand, and for the npm package
the mocks and tests are ignored anyway.
So I think it is safe to ignore them in the babel transformation.

The tests probably fail due to #49 .