### PR TITLE
Pass tests on Windows

### DIFF
--- a/bin/__tests__/react-docgen-test.js
+++ b/bin/__tests__/react-docgen-test.js
@@ -15,15 +15,15 @@ jasmine.getEnv().defaultTimeoutInterval = 10000;
 
 jest.autoMockOff();
 
-var child_process = require('child_process'); // eslint-disable-line camelcase
 var fs = require('fs');
 var path = require('path');
 var rimraf = require('rimraf');
 var temp = require('temp');
+var spawn = require('cross-spawn-async');
 
 function run(args, stdin) {
   return new Promise(resolve => {
-    var docgen = child_process.spawn( // eslint-disable-line camelcase
+    var docgen = spawn( // eslint-disable-line camelcase
       path.join(__dirname, '../react-docgen.js'),
       args
     );

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "babel-jest": "^5.3.0",
     "jest-cli": "^0.8.0",
     "rimraf": "^2.3.2",
-    "temp": "^0.8.1"
+    "temp": "^0.8.1",
+    "cross-spawn-async": "^2.1.9"
   },
   "jest": {
     "preprocessCachingDisabled": true,

--- a/src/handlers/__tests__/propDocblockHandler-test.js
+++ b/src/handlers/__tests__/propDocblockHandler-test.js
@@ -10,6 +10,9 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
+var os = require('os');
+var EOL = os.EOL;
+
 jest.autoMockOff();
 jest.mock('../../Documentation');
 
@@ -67,7 +70,7 @@ describe('propDocBlockHandler', () => {
       expect(documentation.descriptors).toEqual({
         foo: {
           description:
-            'Foo comment with\nmany lines!\n\neven with empty lines in between',
+            'Foo comment with'+EOL+'many lines!'+EOL+'\neven with empty lines in between',
         },
       });
     });

--- a/src/utils/__tests__/docblock-test.js
+++ b/src/utils/__tests__/docblock-test.js
@@ -9,6 +9,8 @@
  */
 
 /*global jest, describe, beforeEach, it, expect*/
+var os = require('os');
+var EOL = os.EOL;
 
 jest
   .dontMock('../docblock');
@@ -57,8 +59,8 @@ describe('docblock', () => {
     });
 
     it('gets the closest docblock of the given node', () => {
-      let node = statement(source.join('\n'));
-      expect(getDocblock(node)).toEqual(comment.join('\n'));
+      let node = statement(source.join(EOL));
+      expect(getDocblock(node)).toEqual(comment.join(EOL));
     });
 
     let terminators = [
@@ -71,7 +73,7 @@ describe('docblock', () => {
     terminators.forEach(t => {
       it('can handle ' + escape(t) + ' as line terminator', () => {
           let node = statement(source.join(t));
-          expect(getDocblock(node)).toEqual(comment.join('\n'));
+          expect(getDocblock(node)).toEqual(comment.join(EOL));
       });
     });
 
@@ -80,7 +82,7 @@ describe('docblock', () => {
         '/** bar */',
         'foo;',
       ];
-      let node = statement(source.join('\n'));
+      let node = statement(source.join(EOL));
       expect(getDocblock(node)).toEqual('bar');
     });
   });


### PR DESCRIPTION
child_process.spawn isn't windows compatibile, so using cross-spawn-aync

end of line tests for docblocks fails on windows, using Node's os.EOL module to handle that in certain tests.

Test pass on windows, hopefully the changes also pass on the CI.