### PR TITLE
Component methods - Improve parameter name parsing and add missing react component method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules/
 
 ## IDE
 .idea/
+
+## Jest
+coverage/

--- a/src/utils/__tests__/getParameterName-test.js
+++ b/src/utils/__tests__/getParameterName-test.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+/*global jest, describe, beforeEach, it, expect*/
+
+jest.autoMockOff();
+
+describe('getParameterName', () => {
+  let getParameterName;
+  let expression;
+
+  beforeEach(() => {
+    getParameterName = require('../getParameterName');
+    ({expression} = require('../../../tests/utils'));
+  });
+
+  it('returns the name for a normal parameter', () => {
+    const def = expression('function(a) {}');
+    const param = def.get('params', 0);
+    expect(getParameterName(param)).toEqual('a');
+  });
+
+  it('returns the name for a rest parameter', () => {
+    const def = expression('function(...a) {}');
+    const param = def.get('params', 0);
+    expect(getParameterName(param)).toEqual('...a');
+  });
+
+  it('returns the name for a parameter with a default value', () => {
+    const def = expression('function(a = 0) {}');
+    const param = def.get('params', 0);
+    expect(getParameterName(param)).toEqual('a');
+  });
+
+  it('returns the raw object representation for a parameter with destructuring', () => {
+    const def = expression('function({a}) {}');
+    const param = def.get('params', 0);
+    expect(getParameterName(param)).toEqual('{a}');
+  });
+
+  it('throws when passed an invalid path', () => {
+    const def = expression('function() {}');
+    const param = def;
+    expect(() => getParameterName(param)).toThrow();
+  });
+});

--- a/src/utils/getMethodDocumentation.js
+++ b/src/utils/getMethodDocumentation.js
@@ -11,6 +11,7 @@
 
 import {getDocblock} from './docblock';
 import getFlowType from './getFlowType';
+import getParameterName from './getParameterName';
 import getPropertyName from './getPropertyName';
 import getTypeAnnotation from './getTypeAnnotation';
 
@@ -44,7 +45,7 @@ function getMethodParamsDoc(methodPath, jsDoc) {
     }
 
     const param = {
-      name: paramPath.node.name,
+      name: getParameterName(paramPath),
       type,
     };
 

--- a/src/utils/getParameterName.js
+++ b/src/utils/getParameterName.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+import recast from 'recast';
+
+import printValue from './printValue';
+
+const {types: {namedTypes: types}} = recast;
+
+export default function getParameterName(parameterPath: NodePath): string {
+  switch (parameterPath.node.type) {
+    case types.Identifier.name:
+      return parameterPath.node.name;
+    case types.AssignmentPattern.name:
+      return getParameterName(parameterPath.get('left'));
+    case types.ObjectPattern.name:
+      return printValue(parameterPath);
+    case types.RestElement.name:
+      return '...' + getParameterName(parameterPath.get('argument'));
+    default:
+      throw new TypeError(
+        'Parameter name must be an Identifier, an AssignmentPattern an ' +
+        `ObjectPattern or a RestElement, got ${parameterPath.node.type}`
+      );
+  }
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -24,6 +24,7 @@ export {default as getMembers} from './getMembers';
 export {default as getMemberValuePath} from './getMemberValuePath';
 export {default as getMethodDocumentation} from './getMethodDocumentation';
 export {default as getNameOrValue} from './getNameOrValue';
+export {default as getParameterName} from './getParameterName';
 export {default as getPropertyName} from './getPropertyName';
 export {default as getPropertyValuePath} from './getPropertyValuePath';
 export {default as getPropType} from './getPropType';

--- a/src/utils/isReactComponentMethod.js
+++ b/src/utils/isReactComponentMethod.js
@@ -16,17 +16,18 @@ import getPropertyName from './getPropertyName';
 const {types: {namedTypes: types}} = recast;
 
 const componentMethods = [
-  'render',
-  'getInitialState',
-  'getDefaultProps',
-  'getChildContext',
-  'componentWillMount',
   'componentDidMount',
-  'componentWillReceiveProps',
-  'shouldComponentUpdate',
-  'componentWillUpdate',
+  'componentDidReceiveProps',
   'componentDidUpdate',
+  'componentWillMount',
+  'componentWillReceiveProps',
   'componentWillUnmount',
+  'componentWillUpdate',
+  'getChildContext',
+  'getDefaultProps',
+  'getInitialState',
+  'render',
+  'shouldComponentUpdate',
 ];
 
 /**


### PR DESCRIPTION
The current implementation returns an empty string for parameter name when using rest parameters, default parameter value or destructuring. I added basic support for these cases so at least something is displayed. Not sure what to do exactly with parameters destructuring but just printing it seemed good enough for now.

It also adds a missing component lifecycle method `componentDidReceiveProps` and reorders them alphabetically.

cc @fkling @danez 