### PR TITLE
Fix findExportedComponentDefinition unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ sudo: false
 language: node_js
 node_js:
   - 4
-  - stable
+  - 5

--- a/src/resolver/__tests__/findExportedComponentDefinition-test.js
+++ b/src/resolver/__tests__/findExportedComponentDefinition-test.js
@@ -483,7 +483,7 @@ describe('findExportedComponentDefinition', () => {
         });
       });
 
-      describe.only('stateless components', () => {
+      describe('stateless components', () => {
 
         it('finds named exports', () => {
           var source = `
@@ -675,12 +675,12 @@ describe('findExportedComponentDefinition', () => {
           var source = `
             import React from 'React';
             var foo = 42;
-            function Component = () { return <div />; }
+            function Component() { return <div />; }
             export {foo, Component};
           `;
           var result = parse(source);
           expect(result).toBeDefined();
-          expect(result.node.type).toBe('ClassExpression');
+          expect(result.node.type).toBe('FunctionDeclaration');
 
           source = `
             import React from 'React';
@@ -690,7 +690,7 @@ describe('findExportedComponentDefinition', () => {
           `;
           result = parse(source);
           expect(result).toBeDefined();
-          expect(result.node.type).toBe('ClassExpression');
+          expect(result.node.type).toBe('ArrowFunctionExpression');
 
           source = `
             import React from 'React';
@@ -701,7 +701,7 @@ describe('findExportedComponentDefinition', () => {
           `;
           result = parse(source);
           expect(result).toBeDefined();
-          expect(result.node.type).toBe('ClassExpression');
+          expect(result.node.type).toBe('FunctionExpression');
         });
 
         it('errors if multiple components are exported', () => {


### PR DESCRIPTION
This suite of tests was *always* being *erroneously* marked as passing due to the `describe.only` on line 486. Even adding `expect(false).toBeTruthy();` to any test would result in this suite still passing.

This PR also fixes the broken tests, including a syntax error in one of the source fixtures.

Note: tests on `master` are currently failing on Node 6.