### PR TITLE
Fix tests on node 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,11 @@
 {
-  "optional": ["runtime"]
+  "presets": [
+    "es2015",
+    "stage-1"
+  ],
+  "plugins": [
+    "syntax-flow",
+    "transform-flow-strip-types",
+    "transform-runtime"
+  ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ language: node_js
 node_js:
   - 4
   - 5
+  - stable

--- a/bin/__tests__/react-docgen-test.js
+++ b/bin/__tests__/react-docgen-test.js
@@ -8,18 +8,19 @@
  *
  */
 
-/*global jasmine, jest, describe, pit, expect, afterEach*/
+/*global jasmine, jest, describe, it, expect, afterEach*/
 
-// Increase default timeout (5000ms) for Travis
-jasmine.getEnv().defaultTimeoutInterval = 10000;
+const TEST_TIMEOUT = 120000;
 
-jest.autoMockOff();
+jasmine.DEFAULT_TIMEOUT_INTERVAL = TEST_TIMEOUT;
+
+jest.disableAutomock();
 
 var fs = require('fs');
 var path = require('path');
 var rimraf = require('rimraf');
 var temp = require('temp');
-var spawn = require('cross-spawn-async');
+var spawn = require('cross-spawn');
 
 function run(args, stdin) {
   return new Promise(resolve => {
@@ -32,6 +33,7 @@ function run(args, stdin) {
     docgen.stdout.on('data', data => stdout += data);
     docgen.stderr.on('data', data => stderr += data);
     docgen.on('close', () => resolve([stdout, stderr]));
+    docgen.on('error', (e) => { throw e; });
     if (stdin) {
       docgen.stdin.write(stdin);
     }
@@ -88,18 +90,18 @@ describe('react-docgen CLI', () => {
       rimraf.sync(tempDir);
     }
     tempDir = null;
-    tempComponents.length = 0;
-    tempNoComponents.length = 0;
+    tempComponents = [];
+    tempNoComponents = [];
   });
 
-  pit('reads from stdin', () => {
+  it('reads from stdin', () => {
     return run([], component).then(([stdout, stderr]) => {
       expect(stdout.length > 0).toBe(true);
       expect(stderr.length).toBe(0);
     });
-  });
+  }, TEST_TIMEOUT);
 
-  pit('reads files provided as command line arguments', () => {
+  it('reads files provided as command line arguments', () => {
     createTempfiles();
     return run(tempComponents.concat(tempNoComponents)).then(
       ([stdout, stderr]) => {
@@ -107,18 +109,18 @@ describe('react-docgen CLI', () => {
         expect(stderr).toContain('NoComponent');
       }
     );
-  });
+  }, TEST_TIMEOUT);
 
-  pit('reads directories provided as command line arguments', () => {
-    tempDir = createTempfiles();
+  it('reads directories provided as command line arguments', () => {
+    createTempfiles();
     return run([tempDir]).then(([stdout, stderr]) => {
       expect(stdout).toContain('Component');
       expect(stderr).toContain('NoComponent');
     });
-  });
+  }, TEST_TIMEOUT);
 
-  pit('considers js and jsx by default', () => {
-    tempDir = createTempfiles();
+  it('considers js and jsx by default', () => {
+    createTempfiles();
     createTempfiles('jsx');
     createTempfiles('foo');
     return run([tempDir]).then(([stdout, stderr]) => {
@@ -130,9 +132,9 @@ describe('react-docgen CLI', () => {
       expect(stderr).toContain('NoComponent.jsx');
       expect(stderr).not.toContain('NoComponent.foo');
     });
-  });
+  }, TEST_TIMEOUT);
 
-  pit('considers files with the specified extension', () => {
+  it('considers files with the specified extension', () => {
     createTempfiles('foo');
     createTempfiles('bar');
 
@@ -144,14 +146,13 @@ describe('react-docgen CLI', () => {
       expect(stderr).toContain('NoComponent.bar');
     };
 
-
     return Promise.all([
       run(['--extension=foo', '--extension=bar', tempDir]).then(verify),
       run(['-x', 'foo', '-x', 'bar', tempDir]).then(verify),
     ]);
-  });
+  }, TEST_TIMEOUT);
 
-  pit('ignores files in node_modules and __tests__ by default', () => {
+  it('ignores files in node_modules and __tests__ by default', () => {
     createTempfiles(null, 'node_modules');
     createTempfiles(null, '__tests__');
 
@@ -159,9 +160,9 @@ describe('react-docgen CLI', () => {
       expect(stdout).toBe('');
       expect(stderr).toBe('');
     });
-  });
+  }, TEST_TIMEOUT);
 
-  pit('ignores specified folders', () => {
+  it('ignores specified folders', () => {
     createTempfiles(null, 'foo');
 
     var verify = ([stdout, stderr]) => {
@@ -173,23 +174,23 @@ describe('react-docgen CLI', () => {
         run(['--ignore=foo', tempDir]).then(verify),
         run(['-i', 'foo', tempDir]).then(verify),
     ]);
-  });
+  }, TEST_TIMEOUT);
 
-  pit('writes to stdout', () => {
+  it('writes to stdout', () => {
     return run([], component).then(([stdout, stderr]) => {
       expect(stdout.length > 0).toBe(true);
       expect(stderr.length).toBe(0);
     });
-  });
+  }, TEST_TIMEOUT);
 
-  pit('writes to stderr', () => {
+  it('writes to stderr', () => {
     return run([], '{}').then(([stdout, stderr]) => {
       expect(stderr.length > 0).toBe(true);
       expect(stdout.length).toBe(0);
     });
-  });
+  }, TEST_TIMEOUT);
 
-  pit('writes to a file if provided', function() {
+  it('writes to a file if provided', () => {
     var outFile = temp.openSync();
     createTempfiles();
 
@@ -202,10 +203,10 @@ describe('react-docgen CLI', () => {
       run(['--out=' + outFile.path, tempDir]).then(verify),
       run(['-o', outFile.path, tempDir]).then(verify),
     ]);
-  });
+  }, TEST_TIMEOUT);
 
   describe('--resolver', () => {
-    pit('accepts the names of built in resolvers', () => {
+    it('accepts the names of built in resolvers', () => {
       return Promise.all([
         // No option passed: same as --resolver=findExportedComponentDefinition
         run([
@@ -229,9 +230,9 @@ describe('react-docgen CLI', () => {
           expect(stdout).toContain('ComponentB');
         }),
       ]);
-    });
+    }, TEST_TIMEOUT);
 
-    pit('accepts a path to a resolver function', () => {
+    it('accepts a path to a resolver function', () => {
       return Promise.all([
         run([
           '--resolver='+path.join(__dirname, './example/customResolver.js'),
@@ -241,7 +242,7 @@ describe('react-docgen CLI', () => {
           expect(stdout).toContain('Custom');
         }),
       ]);
-    });
+    }, TEST_TIMEOUT);
   });
 
 });

--- a/bin/react-docgen.js
+++ b/bin/react-docgen.js
@@ -57,7 +57,7 @@ var argv = require('nomnom')
 var async = require('async');
 var dir = require('node-dir');
 var fs = require('fs');
-var parser = require('../dist/main.js');
+var parser = require('../dist/main');
 var path = require('path');
 
 var output = argv.out;
@@ -69,10 +69,10 @@ var resolver;
 if (argv.resolver) {
   switch(argv.resolver) {
     case 'findAllComponentDefinitions':
-      resolver = require('../dist/resolver/findAllComponentDefinitions');
+      resolver = require('../dist/resolver/findAllComponentDefinitions').default;
       break;
     case 'findExportedComponentDefinition':
-      resolver = require('../dist/resolver/findExportedComponentDefinition');
+      resolver = require('../dist/resolver/findExportedComponentDefinition').default;
       break;
     default: // treat value as module path
       resolver = require(path.resolve(process.cwd(), argv.resolver));

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "dist/main.js",
   "scripts": {
     "watch": "babel src/ --out-dir dist/ --watch",
-    "build": "rm -rf dist/ && babel src/ --out-dir dist/ --ignore __tests__,__mocks__",
+    "build": "rimraf dist/ && babel src/ --out-dir dist/ --ignore __tests__,__mocks__",
     "prepublish": "npm run build",
     "test": "jest"
   },
@@ -25,24 +25,27 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "async": "^1.4.2",
-    "babel-runtime": "~5.8.25",
+    "babel-runtime": "^6.9.2",
     "babylon": "~5.8.3",
     "doctrine": "^1.2.0",
     "node-dir": "^0.1.10",
     "nomnom": "^1.8.1",
-    "recast": "^0.10.41"
+    "recast": "^0.11.5"
   },
   "devDependencies": {
-    "babel": "^5.6.23",
-    "babel-jest": "^5.3.0",
-    "jest-cli": "^0.8.0",
+    "babel-cli": "^6.9.0",
+    "babel-jest": "^12.1.0",
+    "babel-plugin-syntax-flow": "^6.8.0",
+    "babel-plugin-transform-flow-strip-types": "^6.8.0",
+    "babel-plugin-transform-runtime": "^6.9.0",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-stage-1": "^6.5.0",
+    "cross-spawn": "^4.0.0",
+    "jest-cli": "^12.1.1",
     "rimraf": "^2.3.2",
-    "temp": "^0.8.1",
-    "cross-spawn-async": "^2.1.9"
+    "temp": "^0.8.1"
   },
   "jest": {
-    "preprocessCachingDisabled": true,
-    "scriptPreprocessor": "node_modules/babel-jest",
     "setupTestFrameworkScriptFile": "tests/setupTestFramework.js",
     "testPathDirs": [
       "bin",

--- a/src/__tests__/main-test.js
+++ b/src/__tests__/main-test.js
@@ -10,7 +10,7 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('main', () => {
   var docgen, ERROR_MISSING_DEFINITION;
@@ -222,7 +222,7 @@ describe('main', () => {
         export default NotAComponent;
       `;
 
-      expect(() => docgen.parse(source)).toThrow(ERROR_MISSING_DEFINITION);
+      expect(() => docgen.parse(source)).toThrowError(ERROR_MISSING_DEFINITION);
     });
   });
 });

--- a/src/__tests__/parse-test.js
+++ b/src/__tests__/parse-test.js
@@ -10,7 +10,7 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('parse', () => {
   var utils;
@@ -28,8 +28,8 @@ describe('parse', () => {
 
   it('allows custom component definition resolvers', () => {
     var path = pathFromSource('({foo: "bar"})');
-    var resolver = jest.genMockFunction().mockReturnValue(path);
-    var handler = jest.genMockFunction();
+    var resolver = jest.fn(() => path);
+    var handler = jest.fn();
     parse('//empty', resolver, [handler]);
 
     expect(resolver).toBeCalled();
@@ -37,11 +37,11 @@ describe('parse', () => {
   });
 
   it('errors if component definition is not found', () => {
-    var resolver = jest.genMockFunction();
-    expect(() => parse('//empty', resolver)).toThrow(ERROR_MISSING_DEFINITION);
+    var resolver = jest.fn();
+    expect(() => parse('//empty', resolver)).toThrowError(ERROR_MISSING_DEFINITION);
     expect(resolver).toBeCalled();
 
-    expect(() => parse('//empty', resolver)).toThrow(ERROR_MISSING_DEFINITION);
+    expect(() => parse('//empty', resolver)).toThrowError(ERROR_MISSING_DEFINITION);
     expect(resolver).toBeCalled();
   });
 

--- a/src/handlers/__tests__/componentDocblockHandler-test.js
+++ b/src/handlers/__tests__/componentDocblockHandler-test.js
@@ -10,7 +10,7 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 jest.mock('../../Documentation');
 
 describe('componentDocblockHandler', () => {
@@ -29,7 +29,7 @@ describe('componentDocblockHandler', () => {
   beforeEach(() => {
     ({parse} = require('../../../tests/utils'));
     documentation = new (require('../../Documentation'));
-    componentDocblockHandler = require('../componentDocblockHandler');
+    componentDocblockHandler = require('../componentDocblockHandler').default;
   });
 
   function test(definitionSrc, parse) { // eslint-disable-line no-shadow

--- a/src/handlers/__tests__/componentMethodsHandler-test.js
+++ b/src/handlers/__tests__/componentMethodsHandler-test.js
@@ -10,7 +10,7 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 jest.mock('../../Documentation');
 
 describe('componentMethodsHandler', () => {
@@ -21,7 +21,7 @@ describe('componentMethodsHandler', () => {
   beforeEach(() => {
     ({parse} = require('../../../tests/utils'));
     documentation = new (require('../../Documentation'));
-    componentMethodsHandler = require('../componentMethodsHandler');
+    componentMethodsHandler = require('../componentMethodsHandler').default;
   });
 
   function test(definition) {

--- a/src/handlers/__tests__/componentMethodsJsDocHandler-test.js
+++ b/src/handlers/__tests__/componentMethodsJsDocHandler-test.js
@@ -10,7 +10,7 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('componentMethodsHandler', () => {
   let documentation;
@@ -18,7 +18,7 @@ describe('componentMethodsHandler', () => {
 
   beforeEach(() => {
     documentation = new (require('../../Documentation'));
-    componentMethodsJsDocHandler = require('../componentMethodsJsDocHandler');
+    componentMethodsJsDocHandler = require('../componentMethodsJsDocHandler').default;
   });
 
   it('stays the same when no docblock is present', () => {

--- a/src/handlers/__tests__/defaultPropsHandler-test.js
+++ b/src/handlers/__tests__/defaultPropsHandler-test.js
@@ -10,7 +10,7 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 jest.mock('../../Documentation');
 
 describe('defaultPropsHandler', () => {
@@ -21,7 +21,7 @@ describe('defaultPropsHandler', () => {
   beforeEach(() => {
     ({parse} = require('../../../tests/utils'));
     documentation = new (require('../../Documentation'));
-    defaultPropsHandler = require('../defaultPropsHandler');
+    defaultPropsHandler = require('../defaultPropsHandler').default;
   });
 
   function test(definition) {

--- a/src/handlers/__tests__/displayNameHandler-test.js
+++ b/src/handlers/__tests__/displayNameHandler-test.js
@@ -10,7 +10,7 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 jest.mock('../../Documentation');
 
 describe('defaultPropsHandler', () => {
@@ -21,7 +21,7 @@ describe('defaultPropsHandler', () => {
   beforeEach(() => {
     ({expression, statement} = require('../../../tests/utils'));
     documentation = new (require('../../Documentation'));
-    displayNameHandler = require('../displayNameHandler');
+    displayNameHandler = require('../displayNameHandler').default;
   });
 
   it('extracts the displayName', () => {

--- a/src/handlers/__tests__/flowTypeDocBlockHandler-test.js
+++ b/src/handlers/__tests__/flowTypeDocBlockHandler-test.js
@@ -10,7 +10,7 @@
 
 /*global jest, describe, it, expect, beforeEach*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 jest.mock('../../Documentation');
 
 describe('flowTypeDocBlockHandler', () => {
@@ -26,7 +26,7 @@ describe('flowTypeDocBlockHandler', () => {
     jest.mock('../../utils/getFlowType');
 
     documentation = new (require('../../Documentation'));
-    flowTypeDocBlockHandler = require('../flowTypeDocBlockHandler');
+    flowTypeDocBlockHandler = require('../flowTypeDocBlockHandler').default;
   });
 
   function template(src, typeObject) {

--- a/src/handlers/__tests__/flowTypeHandler-test.js
+++ b/src/handlers/__tests__/flowTypeHandler-test.js
@@ -10,7 +10,7 @@
 
 /*global jest, describe, it, expect, beforeEach*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 jest.mock('../../Documentation');
 
 describe('flowTypeHandler', () => {
@@ -26,7 +26,7 @@ describe('flowTypeHandler', () => {
     jest.mock('../../utils/getFlowType');
 
     documentation = new (require('../../Documentation'));
-    flowTypeHandler = require('../flowTypeHandler');
+    flowTypeHandler = require('../flowTypeHandler').default;
   });
 
   function template(src, typeObject) {

--- a/src/handlers/__tests__/propDocblockHandler-test.js
+++ b/src/handlers/__tests__/propDocblockHandler-test.js
@@ -13,7 +13,7 @@
 var os = require('os');
 var EOL = os.EOL;
 
-jest.autoMockOff();
+jest.disableAutomock();
 jest.mock('../../Documentation');
 
 describe('propDocBlockHandler', () => {
@@ -24,7 +24,7 @@ describe('propDocBlockHandler', () => {
   beforeEach(() => {
     ({expression, statement} = require('../../../tests/utils'));
     documentation = new (require('../../Documentation'));
-    propDocBlockHandler = require('../propDocBlockHandler');
+    propDocBlockHandler = require('../propDocBlockHandler').default;
   });
 
   function test(getSrc, parse) {

--- a/src/handlers/__tests__/propTypeCompositionHandler-test.js
+++ b/src/handlers/__tests__/propTypeCompositionHandler-test.js
@@ -10,7 +10,7 @@
 
 /*global jest, describe, it, expect, beforeEach*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 jest.mock('../../Documentation');
 
 describe('propTypeCompositionHandler', () => {
@@ -26,7 +26,7 @@ describe('propTypeCompositionHandler', () => {
     jest.mock('../../utils/getPropType');
 
     documentation = new (require('../../Documentation'))();
-    propTypeCompositionHandler = require('../propTypeCompositionHandler');
+    propTypeCompositionHandler = require('../propTypeCompositionHandler').default;
   });
 
   function test(getSrc, parse) {

--- a/src/handlers/__tests__/propTypeHandler-test.js
+++ b/src/handlers/__tests__/propTypeHandler-test.js
@@ -10,7 +10,7 @@
 
 /*global jest, describe, it, expect, beforeEach*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 jest.mock('../../Documentation');
 
 describe('propTypeHandler', () => {
@@ -26,7 +26,7 @@ describe('propTypeHandler', () => {
     jest.mock('../../utils/getPropType');
 
     documentation = new (require('../../Documentation'));
-    propTypeHandler = require('../propTypeHandler');
+    propTypeHandler = require('../propTypeHandler').default;
   });
 
   function template(src) {

--- a/src/resolver/__tests__/findAllComponentDefinitions-test.js
+++ b/src/resolver/__tests__/findAllComponentDefinitions-test.js
@@ -10,7 +10,7 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('findAllComponentDefinitions', () => {
   var findAllComponentDefinitions;
@@ -25,7 +25,7 @@ describe('findAllComponentDefinitions', () => {
   }
 
   beforeEach(() => {
-    findAllComponentDefinitions = require('../findAllComponentDefinitions');
+    findAllComponentDefinitions = require('../findAllComponentDefinitions').default;
     utils = require('../../../tests/utils');
     recast = require('recast');
   });

--- a/src/resolver/__tests__/findExportedComponentDefinition-test.js
+++ b/src/resolver/__tests__/findExportedComponentDefinition-test.js
@@ -10,7 +10,7 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('findExportedComponentDefinition', () => {
   var findExportedComponentDefinition;
@@ -26,7 +26,7 @@ describe('findExportedComponentDefinition', () => {
 
   beforeEach(() => {
     findExportedComponentDefinition =
-      require('../findExportedComponentDefinition');
+      require('../findExportedComponentDefinition').default;
     utils = require('../../../tests/utils');
     recast = require('recast');
   });

--- a/src/utils/__tests__/docblock-test.js
+++ b/src/utils/__tests__/docblock-test.js
@@ -12,8 +12,7 @@
 var os = require('os');
 var EOL = os.EOL;
 
-jest
-  .dontMock('../docblock');
+jest.unmock('../docblock');
 
 describe('docblock', () => {
 

--- a/src/utils/__tests__/getClassMemberValuePath-test.js
+++ b/src/utils/__tests__/getClassMemberValuePath-test.js
@@ -10,14 +10,14 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('getClassMemberValuePath', () => {
   var getClassMemberValuePath;
   var statement;
 
   beforeEach(() => {
-    getClassMemberValuePath = require('../getClassMemberValuePath');
+    getClassMemberValuePath = require('../getClassMemberValuePath').default;
     ({statement} = require('../../../tests/utils'));
   });
 

--- a/src/utils/__tests__/getFlowType-test.js
+++ b/src/utils/__tests__/getFlowType-test.js
@@ -8,16 +8,16 @@
  *
  */
 
-/*global jest, describe, beforeEach, it, expect*/
+/* global jest, describe, beforeEach, it, expect */
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('getFlowType', () => {
   var expression, statement;
   var getFlowType;
 
   beforeEach(() => {
-    getFlowType = require('../getFlowType');
+    getFlowType = require('../getFlowType').default;
     ({expression, statement} = require('../../../tests/utils'));
   });
 

--- a/src/utils/__tests__/getMemberExpressionRoot-test.js
+++ b/src/utils/__tests__/getMemberExpressionRoot-test.js
@@ -12,10 +12,9 @@
 
 import {expression} from '../../../tests/utils';
 
-jest
-  .dontMock('../getMemberExpressionRoot');
+jest.unmock('../getMemberExpressionRoot');
 
-var getMemberExpressionRoot = require('../getMemberExpressionRoot');
+var getMemberExpressionRoot = require('../getMemberExpressionRoot').default;
 
 describe('getMemberExpressionRoot', () => {
   it('returns the root of a member expression', () => {

--- a/src/utils/__tests__/getMemberExpressionValuePath-test.js
+++ b/src/utils/__tests__/getMemberExpressionValuePath-test.js
@@ -10,14 +10,14 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('getMemberExpressionValuePath', () => {
   var getMemberExpressionValuePath;
   var statement;
 
   beforeEach(() => {
-    getMemberExpressionValuePath = require('../getMemberExpressionValuePath');
+    getMemberExpressionValuePath = require('../getMemberExpressionValuePath').default;
     ({statement} = require('../../../tests/utils'));
   });
 

--- a/src/utils/__tests__/getMemberValuePath-test.js
+++ b/src/utils/__tests__/getMemberValuePath-test.js
@@ -10,8 +10,7 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest
-  .dontMock('../getMemberValuePath.js');
+jest.unmock('../getMemberValuePath');
 
 describe('getMemberValuePath', () => {
   var getMemberValuePath;
@@ -19,11 +18,11 @@ describe('getMemberValuePath', () => {
 
   beforeEach(() => {
     ({expression, statement} = require('../../../tests/utils'));
-    getMemberValuePath = require('../getMemberValuePath');
+    getMemberValuePath = require('../getMemberValuePath').default;
   });
 
   it('handles ObjectExpresisons', () => {
-    var getPropertyValuePath = require('../getPropertyValuePath');
+    var getPropertyValuePath = require('../getPropertyValuePath').default;
     var path = expression('{}');
 
     getMemberValuePath(path, 'foo');
@@ -31,7 +30,7 @@ describe('getMemberValuePath', () => {
   });
 
   it('handles ClassDeclarations', () => {
-    var getClassMemberValuePath = require('../getClassMemberValuePath');
+    var getClassMemberValuePath = require('../getClassMemberValuePath').default;
     var path = statement('class Foo {}');
 
     getMemberValuePath(path, 'foo');
@@ -39,7 +38,7 @@ describe('getMemberValuePath', () => {
   });
 
   it('handles ClassExpressions', () => {
-    var getClassMemberValuePath = require('../getClassMemberValuePath');
+    var getClassMemberValuePath = require('../getClassMemberValuePath').default;
     var path = expression('class {}');
 
     getMemberValuePath(path, 'foo');
@@ -47,8 +46,8 @@ describe('getMemberValuePath', () => {
   });
 
   it('tries synonyms', () => {
-    var getPropertyValuePath = require('../getPropertyValuePath');
-    var getClassMemberValuePath = require('../getClassMemberValuePath');
+    var getPropertyValuePath = require('../getPropertyValuePath').default;
+    var getClassMemberValuePath = require('../getClassMemberValuePath').default;
     var path = expression('{}');
 
     getMemberValuePath(path, 'defaultProps');
@@ -63,8 +62,8 @@ describe('getMemberValuePath', () => {
   });
 
   it('returns the result of getPropertyValuePath and getClassMemberValuePath', () => {
-    var getPropertyValuePath = require('../getPropertyValuePath');
-    var getClassMemberValuePath = require('../getClassMemberValuePath');
+    var getPropertyValuePath = require('../getPropertyValuePath').default;
+    var getClassMemberValuePath = require('../getClassMemberValuePath').default;
     getPropertyValuePath.mockReturnValue(42);
     getClassMemberValuePath.mockReturnValue(21);
     var path = expression('{}');

--- a/src/utils/__tests__/getMembers-test.js
+++ b/src/utils/__tests__/getMembers-test.js
@@ -10,7 +10,7 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('getMembers', () => {
   var expression;
@@ -18,11 +18,10 @@ describe('getMembers', () => {
   var memberExpressionPath;
 
   beforeEach(() => {
-    getMembers = require('../getMembers');
+    getMembers = require('../getMembers').default;
     ({expression} = require('../../../tests/utils'));
     memberExpressionPath = expression('foo.bar(123)(456)[baz][42]');
   });
-
 
   it('finds all "members" "inside" a MemberExpression', () => {
     var members = getMembers(memberExpressionPath);

--- a/src/utils/__tests__/getMethodDocumentation-test.js
+++ b/src/utils/__tests__/getMethodDocumentation-test.js
@@ -10,14 +10,14 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('getMethodDocumentation', () => {
   let getMethodDocumentation;
   let expression, statement;
 
   beforeEach(() => {
-    getMethodDocumentation = require('../getMethodDocumentation');
+    getMethodDocumentation = require('../getMethodDocumentation').default;
     ({expression, statement} = require('../../../tests/utils'));
   });
 

--- a/src/utils/__tests__/getParameterName-test.js
+++ b/src/utils/__tests__/getParameterName-test.js
@@ -10,14 +10,14 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('getParameterName', () => {
   let getParameterName;
   let expression;
 
   beforeEach(() => {
-    getParameterName = require('../getParameterName');
+    getParameterName = require('../getParameterName').default;
     ({expression} = require('../../../tests/utils'));
   });
 

--- a/src/utils/__tests__/getPropType-test.js
+++ b/src/utils/__tests__/getPropType-test.js
@@ -10,14 +10,14 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('getPropType', () => {
   var expression, statement;
   var getPropType;
 
   beforeEach(() => {
-    getPropType = require('../getPropType');
+    getPropType = require('../getPropType').default;
     ({expression, statement} = require('../../../tests/utils'));
   });
 

--- a/src/utils/__tests__/getPropertyValuePath-test.js
+++ b/src/utils/__tests__/getPropertyValuePath-test.js
@@ -10,7 +10,7 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('getPropertyValuePath', () => {
   var recast;
@@ -23,7 +23,7 @@ describe('getPropertyValuePath', () => {
   }
 
   beforeEach(() => {
-    getPropertyValuePath = require('../getPropertyValuePath');
+    getPropertyValuePath = require('../getPropertyValuePath').default;
     recast = require('recast');
   });
 

--- a/src/utils/__tests__/getTypeAnnotation-test.js
+++ b/src/utils/__tests__/getTypeAnnotation-test.js
@@ -10,14 +10,14 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('getTypeAnnotation', () => {
   var expression, statement;
   var getTypeAnnotation;
 
   beforeEach(() => {
-    getTypeAnnotation = require('../getTypeAnnotation');
+    getTypeAnnotation = require('../getTypeAnnotation').default;
     ({expression, statement} = require('../../../tests/utils'));
   });
 

--- a/src/utils/__tests__/isExportsOrModuleAssignment-test.js
+++ b/src/utils/__tests__/isExportsOrModuleAssignment-test.js
@@ -10,7 +10,7 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('isExportsOrModuleAssignment', () => {
   var recast;
@@ -23,7 +23,7 @@ describe('isExportsOrModuleAssignment', () => {
   }
 
   beforeEach(() => {
-    isExportsOrModuleAssignment = require('../isExportsOrModuleAssignment');
+    isExportsOrModuleAssignment = require('../isExportsOrModuleAssignment').default;
     recast = require('recast');
   });
 

--- a/src/utils/__tests__/isReactComponentClass-test.js
+++ b/src/utils/__tests__/isReactComponentClass-test.js
@@ -11,14 +11,14 @@
 /*global jest, describe, beforeEach, it, expect*/
 
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('isReactComponentClass', () => {
   var isReactComponentClass;
   var expression, statement, parse;
 
   beforeEach(() => {
-    isReactComponentClass = require('../isReactComponentClass');
+    isReactComponentClass = require('../isReactComponentClass').default;
     ({expression, statement, parse} = require('../../../tests/utils'));
   });
 

--- a/src/utils/__tests__/isReactComponentMethod-test.js
+++ b/src/utils/__tests__/isReactComponentMethod-test.js
@@ -11,14 +11,14 @@
 /*global jest, describe, beforeEach, it, expect*/
 
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('isReactComponentMethod', () => {
   let isReactComponentMethod;
   let expression, statement;
 
   beforeEach(() => {
-    isReactComponentMethod = require('../isReactComponentMethod');
+    isReactComponentMethod = require('../isReactComponentMethod').default;
     ({expression, statement} = require('../../../tests/utils'));
   });
 

--- a/src/utils/__tests__/isRequiredPropType-test.js
+++ b/src/utils/__tests__/isRequiredPropType-test.js
@@ -10,14 +10,14 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('isRequiredPropType', () => {
   var expression;
   var isRequiredPropType;
 
   beforeEach(() => {
-    isRequiredPropType = require('../isRequiredPropType');
+    isRequiredPropType = require('../isRequiredPropType').default;
     ({expression} = require('../../../tests/utils'));
   });
 

--- a/src/utils/__tests__/isStatelessComponent-test.js
+++ b/src/utils/__tests__/isStatelessComponent-test.js
@@ -11,14 +11,14 @@
 /*global jest, describe, beforeEach, it, expect*/
 
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('isStatelessComponent', () => {
   var isStatelessComponent;
   var statement, parse;
 
   beforeEach(() => {
-    isStatelessComponent = require('../isStatelessComponent');
+    isStatelessComponent = require('../isStatelessComponent').default;
     ({statement, parse} = require('../../../tests/utils'));
   });
 

--- a/src/utils/__tests__/match-test.js
+++ b/src/utils/__tests__/match-test.js
@@ -10,13 +10,13 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('match', () => {
   var match;
 
   beforeEach(() => {
-    match = require('../match');
+    match = require('../match').default;
   });
 
   it('matches with exact properties', () => {

--- a/src/utils/__tests__/normalizeClassDefinition-test.js
+++ b/src/utils/__tests__/normalizeClassDefinition-test.js
@@ -11,9 +11,9 @@
 /*global jest, describe, beforeEach, it, expect*/
 
 jest
-  .dontMock('../normalizeClassDefinition')
-  .dontMock('../getMemberExpressionRoot')
-  .dontMock('../getMembers');
+  .unmock('../normalizeClassDefinition')
+  .unmock('../getMemberExpressionRoot')
+  .unmock('../getMembers');
 
 
 describe('normalizeClassDefinition', () => {
@@ -22,7 +22,7 @@ describe('normalizeClassDefinition', () => {
 
   beforeEach(() => {
     ({parse} = require('../../../tests/utils'));
-    normalizeClassDefinition = require('../normalizeClassDefinition');
+    normalizeClassDefinition = require('../normalizeClassDefinition').default;
   });
 
   it('finds assignments to class declarations', () => {

--- a/src/utils/__tests__/parseJsDoc-test.js
+++ b/src/utils/__tests__/parseJsDoc-test.js
@@ -10,13 +10,13 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('parseJsDoc', () => {
   let parseJsDoc;
 
   beforeEach(() => {
-    parseJsDoc = require('../parseJsDoc');
+    parseJsDoc = require('../parseJsDoc').default;
   });
 
   describe('description', () => {

--- a/src/utils/__tests__/printValue-test.js
+++ b/src/utils/__tests__/printValue-test.js
@@ -10,14 +10,14 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('printValue', () => {
   var printValue;
   var utils;
 
   beforeEach(() => {
-    printValue = require('../printValue');
+    printValue = require('../printValue').default;
     utils = require('../../../tests/utils');
   });
 

--- a/src/utils/__tests__/resolveExportDeclaration-test.js
+++ b/src/utils/__tests__/resolveExportDeclaration-test.js
@@ -10,10 +10,9 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-import {statement} from '../../../tests/utils';
+import { statement } from '../../../tests/utils';
 
-jest
-  .dontMock('../resolveExportDeclaration');
+jest.unmock('../resolveExportDeclaration');
 
 
 describe('resolveExportDeclaration', () => {
@@ -22,9 +21,9 @@ describe('resolveExportDeclaration', () => {
   var resolveExportDeclaration;
 
   beforeEach(() => {
-    resolveToValue = require('../resolveToValue');
+    resolveToValue = require('../resolveToValue').default;
     resolveToValue.mockReturnValue(returnValue);
-    resolveExportDeclaration = require('../resolveExportDeclaration');
+    resolveExportDeclaration = require('../resolveExportDeclaration').default;
   });
 
   it('resolves default exports', () => {

--- a/src/utils/__tests__/resolveToModule-test.js
+++ b/src/utils/__tests__/resolveToModule-test.js
@@ -10,7 +10,7 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('resolveToModule', () => {
   var utils;
@@ -22,7 +22,7 @@ describe('resolveToModule', () => {
   }
 
   beforeEach(() => {
-    resolveToModule = require('../resolveToModule');
+    resolveToModule = require('../resolveToModule').default;
     utils = require('../../../tests/utils');
   });
 

--- a/src/utils/__tests__/resolveToValue-test.js
+++ b/src/utils/__tests__/resolveToValue-test.js
@@ -10,7 +10,7 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
-jest.autoMockOff();
+jest.disableAutomock();
 
 describe('resolveToValue', () => {
   var builders;
@@ -25,7 +25,7 @@ describe('resolveToValue', () => {
   beforeEach(() => {
     var recast = require('recast');
     builders = recast.types.builders;
-    resolveToValue = require('../resolveToValue');
+    resolveToValue = require('../resolveToValue').default;
     utils = require('../../../tests/utils');
   });
 

--- a/tests/setupTestFramework.js
+++ b/tests/setupTestFramework.js
@@ -3,19 +3,23 @@
 var recast = require('recast');
 
 var matchers = {
-  toEqualASTNode: function compare(expected) {
-    if (!expected || typeof expected !== 'object') {
-      throw new Error(
-        'Expected value must be an object representing an AST node.\n' +
-        'Got ' + expected + '(' + typeof expected + ') instead.'
-      );
-    }
+  toEqualASTNode: function () {
+    return {
+      compare: function (actual, expected) {
+        if (!expected || typeof expected !== 'object') {
+          throw new Error(
+            'Expected value must be an object representing an AST node.\n' +
+            'Got ' + expected + '(' + typeof expected + ') instead.'
+          );
+        }
 
-    return recast.types.astNodesAreEquivalent(this.actual, expected);
-  },
+        return {pass: recast.types.astNodesAreEquivalent(actual, expected)};
+      }
+    };
+  }
 };
 
 
 jasmine.getEnv().beforeEach(function() {
-  this.addMatchers(matchers);
+  jasmine.addMatchers(matchers);
 });


### PR DESCRIPTION
The tests were failing on node v6 because jest 0.8 and node 6 were not compatible. What I did is updating jest to 12 and then the journey began as jest 12 only supports babel 6.

In total this was done:

* Update jest to latest version
* Update babel-jest to latest version
* Upgrading babel to latest version (6.9) for jest
* Rewrite the custom matcher to conform to jasmine2 specs
* Fix deprecated jest apis (autoMockOff() => disableAutomock(), dontMock() => unmock())
* Babel 6 is not exporting the default export as module.export, so `.default` had to be added in the tests and the binary in order for the require() to work
* As I was already updating stuff I also switched from `cross-spawn-async` to `cross-spawn`, as the first one is deprecated.
* changed from `rm -rf` to `rimraf` in `npm build` for windows support.
* Update recast to 0.11.x as the only change from 0.10 to 0.11 was the default parser switched from esprima-fb to esprima, but react-docgen is using babylon anyway.
* Some tests for stateless components in `findExportedComponentDefinition` were broken and not run as there was a `desribe.only` which made the old jest silently ignoring these tests.

(Babylon is still at version 5.8, if there is ever the need to update babylon then this is complete separate story)