### PR TITLE
Change typealias name add param optional

### DIFF
--- a/src/utils/getMethodDocumentation.js
+++ b/src/utils/getMethodDocumentation.js
@@ -14,10 +14,14 @@ import getFlowType from './getFlowType';
 import getParameterName from './getParameterName';
 import getPropertyName from './getPropertyName';
 import getTypeAnnotation from './getTypeAnnotation';
+import recast from 'recast';
+
+const { types: { namedTypes: types } } = recast;
 
 type MethodParameter = {
   name: string;
   type?: ?FlowTypeDescriptor;
+  optional?: boolean;
 };
 
 type MethodReturn = {
@@ -42,10 +46,14 @@ function getMethodParamsDoc(methodPath, jsDoc) {
     const typePath = getTypeAnnotation(paramPath);
     if (typePath) {
       type = getFlowType(typePath);
+      if (types.GenericTypeAnnotation.check(typePath.node)) {
+        type.alias = typePath.node.id.name;
+      }
     }
 
     const param = {
       name: getParameterName(paramPath),
+      optional: paramPath.node.optional,
       type,
     };
 


### PR DESCRIPTION
To support some proposed React Native doc updates, here are two changes:

1. Expose the type name, ex: the code below would like to see type.name set to StatusBarStyle instead of $Enum:

        export type StatusBarStyle = $Enum<{
             ...
        }

2. Expose whether a method's parameter is optional or not. Currently this isn't brought out.