### PR TITLE
Handle optional param types when parsing jsdoc format

### DIFF
--- a/src/utils/__tests__/parseJsDoc-test.js
+++ b/src/utils/__tests__/parseJsDoc-test.js
@@ -64,6 +64,22 @@ describe('parseJsDoc', () => {
       });
     });
 
+    it('extracts jsdoc optional', () => {
+      const docblock = `
+        @param {string=} bar
+      `;
+      expect(parseJsDoc(docblock)).toEqual({
+        description: null,
+        returns: null,
+        params: [{
+          name: 'bar',
+          type: {name: 'string'},
+          description: null,
+          optional: true,
+        }],
+      });
+    });
+
     describe('returns', () => {
 
       it('returns null if return is not documented', () => {

--- a/src/utils/parseJsDoc.js
+++ b/src/utils/parseJsDoc.js
@@ -17,6 +17,7 @@ type JsDoc = {
     name: string;
     description: ?string;
     type: ?{name: string};
+    optional?: boolean;
   }];
   returns: ?{
     description: ?string;
@@ -28,7 +29,14 @@ function getType(tag) {
   if (!tag.type) {
     return null;
   }
-  return {name: tag.type.name};
+  return {name: tag.type.name ? tag.type.name : tag.type.expression.name};
+}
+
+function getOptional(tag) {
+  if (tag.type && tag.type.type && tag.type.type === 'OptionalType') {
+    return true;
+  }
+  return;
 }
 
 // Add jsdoc @return description.
@@ -57,6 +65,7 @@ function getParamsJsDoc(jsDoc) {
         name: tag.name,
         description: tag.description,
         type: getType(tag),
+        optional: getOptional(tag),
       };
     });
 }


### PR DESCRIPTION
Found an issue with optional parameter types when documenting a component without Flow annotations and having to rely on jsdoc format. The type is erroneously passed back as `null` as the logic looks for `type.name` and it should instead look for `type.expression.name` for optional types.

As part of this change, I also exposed an `optional` property for the parameter for doc formatting purposes.

Doctrine: with optional parameter
https://tonicdev.com/576a0e802ae39e13008feb2f/576a0e802ae39e13008feb30

Doctrine: parameter required
https://tonicdev.com/576a0e802ae39e13008feb2f/576a13d18f0383130020cf21

From logging the internals, this is what the ast looks after passing an optional parameter through doctrine and before the type info is extracted by react-docgen:

```
{
  "description": "Replace a scene as specified by an index.",
  "tags": [
    {
      "title": "param",
      "description": "Route representing the new scene to render.",
      "type": {
        "type": "NameExpression",
        "name": "object"
      },
      "name": "route"
    },
    {
      "title": "param",
      "description": "The route in the stack that should be replaced.\n  If negative, it counts from the back of the stack.",
      "type": {
        "type": "NameExpression",
        "name": "number"
      },
      "name": "index"
    },
    {
      "title": "param",
      "description": "Callback function when the scene has been replaced.",
      "type": {
        "type": "OptionalType",
        "expression": {
          "type": "NameExpression",
          "name": "Function"
        }
      },
      "name": "cb"
    }
  ]
}
```

