### PR TITLE
Refactor for flow intersection and union Props

### DIFF
--- a/flow/react-docgen.js
+++ b/flow/react-docgen.js
@@ -40,6 +40,7 @@ type FlowTypeDescriptor = {
   elements?: Array<FlowTypeDescriptor>,
   type?: 'object' | 'function',
   signature?: flowObjectSignatureType | flowFunctionSignatureType,
+  alias?: string,
 };
 
 type PropDescriptor = {

--- a/src/handlers/__tests__/flowTypeDocBlockHandler-test.js
+++ b/src/handlers/__tests__/flowTypeDocBlockHandler-test.js
@@ -127,6 +127,52 @@ describe('flowTypeDocBlockHandler', () => {
       .not.toThrow();
   });
 
+  it('supports intersection proptypes', () => {
+    var definition = statement(`
+      (props: Props) => <div />;
+
+      var React = require('React');
+      import type Imported from 'something';
+
+      type BarProps = {
+        /** bar description */
+        bar: 'barValue'
+      }
+
+      type Props = Imported & BarProps & {
+        /** foo description */
+        foo: 'fooValue'
+      };
+    `).get('expression');
+
+    flowTypeDocBlockHandler(documentation, definition);
+
+    expect(documentation.descriptors).toEqual({
+      foo: {
+        description: 'foo description',
+      },
+      bar: {
+        description: 'bar description',
+      },
+    });
+
+    it('does not support union proptypes', () => {
+      var definition = statement(`
+        (props: Props) => <div />;
+
+        var React = require('React');
+        import type Imported from 'something';
+
+        type Other = { bar: 'barValue' };
+        type Props = Imported | Other | { foo: 'fooValue' };
+      `).get('expression');
+
+      expect(() => flowTypeDocBlockHandler(documentation, definition))
+        .toThrowError(TypeError, "react-docgen doesn't support Props of union types");
+    });
+  });
+
+
   describe('does not error for unreachable type', () => {
     function test(code) {
       var definition = statement(code).get('expression');

--- a/src/handlers/__tests__/flowTypeHandler-test.js
+++ b/src/handlers/__tests__/flowTypeHandler-test.js
@@ -170,13 +170,12 @@ describe('flowTypeHandler', () => {
   it('supports intersection proptypes', () => {
     var definition = statement(`
       (props: Props) => <div />;
-     
+
       var React = require('React');
       import type Imported from 'something';
-  
+
       type Props = Imported & { foo: 'bar' };
     `).get('expression');
-
 
     flowTypeHandler(documentation, definition);
 
@@ -188,24 +187,19 @@ describe('flowTypeHandler', () => {
     });
   });
 
-  it('supports union proptypes', () => {
+  it('does not support union proptypes', () => {
     var definition = statement(`
       (props: Props) => <div />;
-      
+
       var React = require('React');
       import type Imported from 'something';
 
-      type Props = Imported | { foo: 'bar' };
+      type Other = { bar: 'barValue' };
+      type Props = Imported | Other | { foo: 'fooValue' };
     `).get('expression');
 
-    flowTypeHandler(documentation, definition);
-
-    expect(documentation.descriptors).toEqual({
-      foo: {
-        flowType: {},
-        required: true,
-      },
-    });
+    expect(() => flowTypeHandler(documentation, definition))
+      .toThrowError(TypeError, "react-docgen doesn't support Props of union types");
   });
 
   describe('does not error for unreachable type', () => {

--- a/src/handlers/flowTypeDocBlockHandler.js
+++ b/src/handlers/flowTypeDocBlockHandler.js
@@ -12,7 +12,9 @@
 
 import type Documentation from '../Documentation';
 import setPropDescription from '../utils/setPropDescription';
-import getFlowTypeFromReactComponent from '../utils/getFlowTypeFromReactComponent';
+import getFlowTypeFromReactComponent, {
+  applyToFlowTypeProperties,
+}  from '../utils/getFlowTypeFromReactComponent';
 
 /**
  * This handler tries to find flow Type annotated react components and extract
@@ -20,11 +22,13 @@ import getFlowTypeFromReactComponent from '../utils/getFlowTypeFromReactComponen
  * inlined in the type definition.
  */
 export default function flowTypeDocBlockHandler(documentation: Documentation, path: NodePath) {
-  let flowTypesPath = getFlowTypeFromReactComponent(path);
+  const flowTypesPath = getFlowTypeFromReactComponent(path);
 
   if (!flowTypesPath) {
     return;
   }
 
-  flowTypesPath.get('properties').each(propertyPath => setPropDescription(documentation, propertyPath));
+  applyToFlowTypeProperties(flowTypesPath, propertyPath =>
+    setPropDescription(documentation, propertyPath)
+  );
 }

--- a/src/handlers/flowTypeHandler.js
+++ b/src/handlers/flowTypeHandler.js
@@ -14,27 +14,23 @@ import type Documentation from '../Documentation';
 
 import getFlowType from '../utils/getFlowType';
 import getPropertyName from '../utils/getPropertyName';
-import getFlowTypeFromReactComponent from '../utils/getFlowTypeFromReactComponent';
+import getFlowTypeFromReactComponent, {
+  applyToFlowTypeProperties,
+}  from '../utils/getFlowTypeFromReactComponent';
+import isUnreachableFlowType from '../utils/isUnreachableFlowType';
+import recast from 'recast';
+import resolveToValue from '../utils/resolveToValue';
+import { getDocblock } from '../utils/docblock';
+
+
+var {types: {namedTypes: types}} = recast;
 
 function setPropDescriptor(documentation: Documentation, path: NodePath): void {
   const propDescriptor = documentation.getPropDescriptor(getPropertyName(path));
   const type = getFlowType(path.get('value'));
-
   if (type) {
     propDescriptor.flowType = type;
     propDescriptor.required = !path.node.optional;
-  }
-}
-
-function findAndSetTypes(documentation: Documentation, path: NodePath): void {
-  if (path.node.properties) {
-    path.get('properties').each(
-      propertyPath => setPropDescriptor(documentation, propertyPath)
-    );
-  } else if (path.node.types) {
-    path.get('types').each(
-      typesPath => findAndSetTypes(documentation, typesPath)
-    );
   }
 }
 
@@ -50,5 +46,7 @@ export default function flowTypeHandler(documentation: Documentation, path: Node
     return;
   }
 
-  findAndSetTypes(documentation, flowTypesPath);
+  applyToFlowTypeProperties(flowTypesPath, propertyPath => {
+      setPropDescriptor(documentation, propertyPath)
+  });
 }


### PR DESCRIPTION
This follows up to the flow support added by @danez

Refactor to resolve, when possible, a list of props
from a flow intersection type and to throw an error
when encountering a Props of union type.

This change addresses a bug found in the flowTypeDocBlockHandler
while a props type that is an IntersectionTypeAnnotation or a
UnionTypeAnnotation.

Union types throw an error, rather than generating misleading documentation.
When given a union type, flow will enforce that props conform to only one of
the union-ed types. The documentation format, which lists a single set of props
can't express this. 