### PR TITLE
Check for import declaration type when getting default values, resolves #63

### DIFF
--- a/src/handlers/__tests__/defaultPropsHandler-test.js
+++ b/src/handlers/__tests__/defaultPropsHandler-test.js
@@ -86,6 +86,27 @@ describe('defaultPropsHandler', () => {
       `;
       test(parse(src).get('body', 0));
     });
+
+    it('should find prop default values that are imported variables', () => {
+      var src = `
+        import ImportedComponent from './ImportedComponent';
+
+        class Foo {
+          static defaultProps = {
+            foo: ImportedComponent,
+          };
+        }
+      `;
+      defaultPropsHandler(documentation, parse(src).get('body', 1));
+      expect(documentation.descriptors).toEqual({
+        foo: {
+          defaultValue: {
+            value: 'ImportedComponent',
+            computed: true,
+          },
+        },
+      });
+    });
   });
 
   describe('ClassExpression with static defaultProps', () => {

--- a/src/handlers/defaultPropsHandler.js
+++ b/src/handlers/defaultPropsHandler.js
@@ -27,8 +27,12 @@ function getDefaultValue(path) {
     defaultValue = node.raw;
   } else {
     path = resolveToValue(path);
-    node = path.node;
-    defaultValue = printValue(path);
+    if (types.ImportDeclaration.check(path.node)) {
+      defaultValue = node.name;
+    } else {
+      node = path.node;
+      defaultValue = printValue(path);
+    }
   }
   if (typeof defaultValue !== 'undefined') {
     return {


### PR DESCRIPTION
A common pattern in libraries is to set a default prop value as an imported component, for eg. a transition component for a dialog.

#63 has an example + a workaround (not the most elegant however, involves using a functional component to return the default component).

Right now, `react-docgen` throws an error on components implementing this pattern as `ImportDefaultDeclaration` is not a printable type.

This PR adds a conditional after the `resolveToValue(path)` call in `getDefaultValue(path)` to check if the node is an import declaration. If so, it returns the `.name` property of the original node (so the function/component name).
