### PR TITLE
Tolerate non-object flow types.

### DIFF
--- a/src/handlers/__tests__/flowTypeDocBlockHandler-test.js
+++ b/src/handlers/__tests__/flowTypeDocBlockHandler-test.js
@@ -167,6 +167,16 @@ describe('flowTypeDocBlockHandler', () => {
       `);
     });
 
+    it('non-object', () => {
+      test(`
+        (props: Props) => <div />;
+        var React = require('React');
+        var Component = React.Component;
+
+        type Props = {a: number} & {b: number};
+      `);
+    });
+
     it('not in scope', () => {
       test(`
         (props: Props) => <div />;

--- a/src/handlers/flowTypeDocBlockHandler.js
+++ b/src/handlers/flowTypeDocBlockHandler.js
@@ -22,7 +22,7 @@ import getFlowTypeFromReactComponent from '../utils/getFlowTypeFromReactComponen
 export default function flowTypeDocBlockHandler(documentation: Documentation, path: NodePath) {
   let flowTypesPath = getFlowTypeFromReactComponent(path);
 
-  if (!flowTypesPath) {
+  if (!flowTypesPath || !flowTypesPath.node.properties) {
     return;
   }
 


### PR DESCRIPTION
React-docgen fails if props flow type is not an object.