### PR TITLE
added exclude cli parameter to exclude files by pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Options:
    -o FILE, --out FILE   store extracted information in FILE
    --pretty              pretty print JSON
    -x, --extension       File extensions to consider. Repeat to define multiple extensions. Default:  [js,jsx]
-   -e, --exclude         Filename pattern to exclude. Default:  [index.js]
+   -e, --exclude         Filename pattern to exclude. Default:  []
    -i, --ignore          Folders to ignore. Default:  [node_modules,__tests__]
    --resolver RESOLVER   Resolver name (findAllComponentDefinitions, findExportedComponentDefinition) or
       path to a module that exports a resolver.  [findExportedComponentDefinition]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Options:
    -o FILE, --out FILE   store extracted information in FILE
    --pretty              pretty print JSON
    -x, --extension       File extensions to consider. Repeat to define multiple extensions. Default:  [js,jsx]
+   -e, --exclude         Filename pattern to exclude. Default:  [index.js]
    -i, --ignore          Folders to ignore. Default:  [node_modules,__tests__]
    --resolver RESOLVER   Resolver name (findAllComponentDefinitions, findExportedComponentDefinition) or
       path to a module that exports a resolver.  [findExportedComponentDefinition]

--- a/bin/react-docgen.js
+++ b/bin/react-docgen.js
@@ -44,7 +44,7 @@ var argv = require('nomnom')
       full: 'exclude',
       help: 'Filename pattern to exclude. Default:',
       list: true,
-      default: ['index.js'],
+      default: [],
     },
     ignoreDir: {
       abbr: 'i',

--- a/bin/react-docgen.js
+++ b/bin/react-docgen.js
@@ -39,6 +39,13 @@ var argv = require('nomnom')
       list: true,
       default: ['js', 'jsx'],
     },
+    excludePatterns: {
+      abbr: 'e',
+      full: 'exclude',
+      help: 'Filename pattern to exclude. Default:',
+      list: true,
+      default: ['index.js'],
+    },
     ignoreDir: {
       abbr: 'i',
       full: 'ignore',
@@ -64,6 +71,7 @@ var output = argv.out;
 var paths = argv.path || [];
 var extensions = new RegExp('\\.(?:' + argv.extension.join('|') + ')$');
 var ignoreDir = argv.ignoreDir;
+var excludePatterns = argv.excludePatterns;
 var resolver;
 
 if (argv.resolver) {
@@ -115,7 +123,8 @@ function traverseDir(filePath, result, done) {
     filePath,
     {
       match: extensions,
-      excludeDir: ignoreDir,
+      exclude:excludePatterns,
+      excludeDir: ignoreDir
     },
     function(error, content, filename, next) {
       if (error) {


### PR DESCRIPTION
hi,
i added a cli parameter 'exclude' to confugure some filename patterns from parsing.
the default is set to ['**index.js**'] because is a common use to organize components in indexed namespaces
Es.
```
/package.json
/app.js
/components/
/components/namespace1/index.js
/components/namespace1/Component1.js
/components/namespace1/Component2.js

```
where index.js is:
```
export Component1 from './Component1'
export Component2 from './Component2'

```
and app.js imports these components with:
`import {Component1, Component2} from './components/namespace1'`

i know that someone use the pattern `/components/ComponentName/index.js` (i don't like this) so... maybe is better to set [] as default...