### PR TITLE
update jest to 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "babel-cli": "^6.9.0",
     "babel-eslint": "^6.0.4",
-    "babel-jest": "^12.1.0",
+    "babel-jest": "^14.1.0",
     "babel-plugin-syntax-flow": "^6.8.0",
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-plugin-transform-runtime": "^6.9.0",
@@ -45,7 +45,7 @@
     "babel-preset-stage-1": "^6.5.0",
     "cross-spawn": "^4.0.0",
     "eslint": "^2.10.2",
-    "jest-cli": "^12.1.1",
+    "jest-cli": "^14.1.0",
     "rimraf": "^2.3.2",
     "temp": "^0.8.1"
   },


### PR DESCRIPTION
updated jest, ran `npm run test` and tests passed on my OSX machine, so from what I can tell no breaking changes for this repo.