### PR TITLE
Fix #101 - Do not fail on invalid flowTypes

### DIFF
--- a/src/handlers/__tests__/flowTypeDocBlockHandler-test.js
+++ b/src/handlers/__tests__/flowTypeDocBlockHandler-test.js
@@ -128,13 +128,13 @@ describe('flowTypeDocBlockHandler', () => {
   });
 
   describe('does not error for unreachable type', () => {
-    function test(code) {
+    function test(code, expected = {}) {
       var definition = statement(code).get('expression');
 
       expect(() => flowTypeDocBlockHandler(documentation, definition))
         .not.toThrow();
 
-      expect(documentation.descriptors).toEqual({});
+      expect(documentation.descriptors).toEqual(expected);
     }
 
     it('required', () => {
@@ -164,6 +164,36 @@ describe('flowTypeDocBlockHandler', () => {
         var Component = React.Component;
 
         import type Props from 'something';
+      `);
+    });
+
+    it('intersection type', () => {
+      test(`
+        (props: Props) => <div />;
+        var React = require('React');
+        var Component = React.Component;
+
+        type Props = { a: string } & { b: string };
+      `, { a: { description: ''}, b: { description: ''} });
+    });
+
+    it('union type', () => {
+      test(`
+        (props: Props) => <div />;
+        var React = require('React');
+        var Component = React.Component;
+
+        type Props = { a: string } | { b: string };
+      `, { a: { description: ''}, b: { description: ''} });
+    });
+
+    it('invalid type', () => {
+      test(`
+        (props: Props) => <div />;
+        var React = require('React');
+        var Component = React.Component;
+
+        type Props = string;
       `);
     });
 

--- a/src/handlers/flowTypeDocBlockHandler.js
+++ b/src/handlers/flowTypeDocBlockHandler.js
@@ -13,6 +13,7 @@
 import type Documentation from '../Documentation';
 import setPropDescription from '../utils/setPropDescription';
 import getFlowTypeFromReactComponent from '../utils/getFlowTypeFromReactComponent';
+import findFlowTypeProps from '../utils/findFlowTypeProps';
 
 /**
  * This handler tries to find flow Type annotated react components and extract
@@ -26,5 +27,5 @@ export default function flowTypeDocBlockHandler(documentation: Documentation, pa
     return;
   }
 
-  flowTypesPath.get('properties').each(propertyPath => setPropDescription(documentation, propertyPath));
+  findFlowTypeProps(documentation, flowTypesPath, setPropDescription);
 }

--- a/src/handlers/flowTypeHandler.js
+++ b/src/handlers/flowTypeHandler.js
@@ -15,6 +15,7 @@ import type Documentation from '../Documentation';
 import getFlowType from '../utils/getFlowType';
 import getPropertyName from '../utils/getPropertyName';
 import getFlowTypeFromReactComponent from '../utils/getFlowTypeFromReactComponent';
+import findFlowTypeProps from '../utils/findFlowTypeProps';
 
 function setPropDescriptor(documentation: Documentation, path: NodePath): void {
   const propDescriptor = documentation.getPropDescriptor(getPropertyName(path));
@@ -23,18 +24,6 @@ function setPropDescriptor(documentation: Documentation, path: NodePath): void {
   if (type) {
     propDescriptor.flowType = type;
     propDescriptor.required = !path.node.optional;
-  }
-}
-
-function findAndSetTypes(documentation: Documentation, path: NodePath): void {
-  if (path.node.properties) {
-    path.get('properties').each(
-      propertyPath => setPropDescriptor(documentation, propertyPath)
-    );
-  } else if (path.node.types) {
-    path.get('types').each(
-      typesPath => findAndSetTypes(documentation, typesPath)
-    );
   }
 }
 
@@ -50,5 +39,5 @@ export default function flowTypeHandler(documentation: Documentation, path: Node
     return;
   }
 
-  findAndSetTypes(documentation, flowTypesPath);
+  findFlowTypeProps(documentation, flowTypesPath, setPropDescriptor);
 }

--- a/src/utils/findFlowTypeProps.js
+++ b/src/utils/findFlowTypeProps.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2016, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ *
+ */
+
+import type Documentation from '../Documentation';
+type SetPropCallback = (documentation: Documentation, path: NodePath) => void
+
+/**
+ * Tries to find all props from the flow annotation and calls the setPropCallback for each one.
+ * The callback can be called multiple times for the same prop (Union, Intersection).
+ */
+export default function findFlowTypeProps(documentation: Documentation, path: NodePath, setPropCallback: SetPropCallback): void {
+  if (path.node.properties) {
+    path.get('properties').each(
+      propertyPath => setPropCallback(documentation, propertyPath)
+    );
+  } else if (path.node.types) {
+    path.get('types').each(
+      typesPath => findFlowTypeProps(documentation, typesPath, setPropCallback)
+    );
+  }
+}


### PR DESCRIPTION
Extract algorithm for finding props in flowType to utils from
flowTypeHandler so that it can be also used in flowTypeDocBlockHandler.

The same error that is described in #101 was already fixed #78 but then not carried on to the DocBlock Handler as well.