### PR TITLE
Add flow-bin, update jest and fix flow error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,4 @@ node_js:
   - 4
   - 5
   - stable
-script:
-  - npm run lint
-  - npm run test
+script: npm run check

--- a/flow/react-docgen.js
+++ b/flow/react-docgen.js
@@ -33,6 +33,7 @@ type flowFunctionSignatureType = {
 
 type FlowTypeDescriptor = {
   name: string,
+  alias?: string,
   value?: string,
   required?: boolean,
   nullable?: boolean,

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   },
   "main": "dist/main.js",
   "scripts": {
+    "check": "npm run lint && npm run flow && npm test",
+    "flow": "flow",
     "lint": "eslint src/",
     "watch": "babel src/ --out-dir dist/ --watch",
     "build": "rimraf dist/ && babel src/ --out-dir dist/ --ignore __tests__,__mocks__",
@@ -37,15 +39,16 @@
   "devDependencies": {
     "babel-cli": "^6.9.0",
     "babel-eslint": "^6.0.4",
-    "babel-jest": "^12.1.0",
+    "babel-jest": "^14.1.0",
     "babel-plugin-syntax-flow": "^6.8.0",
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-1": "^6.5.0",
     "cross-spawn": "^4.0.0",
-    "eslint": "^2.10.2",
-    "jest-cli": "^12.1.1",
+    "eslint": "^3.2.2",
+    "flow-bin": "^0.30.0",
+    "jest-cli": "^14.1.0",
     "rimraf": "^2.3.2",
     "temp": "^0.8.1"
   },


### PR DESCRIPTION
This makes travis to run flow, eslint and the tests.
I hope it is okay that I added flow. If not I can als remove it again form this PR and just fix the flow error.

```
src/utils/getMethodDocumentation.js:48
 48:       type = getFlowType(typePath);
                  ^^^^^^^^^^^^^^^^^^^^^ function call
 50:         type.alias = typePath.node.id.name;
                  ^^^^^ property `alias`. Property not found in
 50:         type.alias = typePath.node.id.name;
             ^^^^ object type


```