### PR TITLE
Add checking stateless component default props

### DIFF
--- a/src/handlers/__tests__/defaultPropsHandler-test.js
+++ b/src/handlers/__tests__/defaultPropsHandler-test.js
@@ -148,4 +148,30 @@ describe('defaultPropsHandler', () => {
     });
   });
 
+  describe('Functional components with default params', () => {
+    it('should find default props that are literals', () => {
+      var src = `
+        ({
+          foo = "bar",
+          bar = 42,
+          baz = ["foo", "bar"],
+          abc = {xyz: abc.def, 123: 42}
+        }) => <div />
+      `;
+      test(parse(src).get('body', 0, 'expression'));
+    });
+
+    it('should override with defaultProps if available', () => {
+      var src = `
+        var Foo = ({
+          foo = "bar",
+          bar = 42,
+          baz = ["foo", "bar"],
+          abc = 'test'
+        }) => <div />
+        Foo.defaultProps = { abc: {xyz: abc.def, 123: 42} };
+      `;
+      test(parse(src).get('body', 0, 'declarations', 0, 'init'));
+    })
+  });
 });

--- a/src/handlers/__tests__/defaultPropsHandler-test.js
+++ b/src/handlers/__tests__/defaultPropsHandler-test.js
@@ -172,6 +172,18 @@ describe('defaultPropsHandler', () => {
         Foo.defaultProps = { abc: {xyz: abc.def, 123: 42} };
       `;
       test(parse(src).get('body', 0, 'declarations', 0, 'init'));
-    })
+    });
+
+    it('should work with aliases', () => {
+      var src = `
+        ({
+          foo = "bar",
+          bar = 42,
+          baz = ["foo", "bar"],
+          abc: defg = {xyz: abc.def, 123: 42}
+        }) => <div />
+      `;
+      test(parse(src).get('body', 0, 'expression'));
+    });
   });
 });

--- a/src/handlers/defaultPropsHandler.js
+++ b/src/handlers/defaultPropsHandler.js
@@ -21,7 +21,7 @@ import isStatelessComponent from '../utils/isStatelessComponent';
 
 var {types: {namedTypes: types, visit}} = recast;
 
-function getDefaultValue(path) {
+function getDefaultValue(path: NodePath) {
   var node = path.node;
   var defaultValue;
   if (types.Literal.check(node)) {
@@ -49,11 +49,11 @@ function getDefaultValue(path) {
   }
 }
 
-function getStatelessPropsPath(componentDefinition) {
+function getStatelessPropsPath(componentDefinition): NodePath {
   return resolveToValue(componentDefinition).get('params', 0);
 }
 
-function getDefaultPropsPath(componentDefinition) {
+function getDefaultPropsPath(componentDefinition: NodePath): ?NodePath {
   var defaultPropsPath = getMemberValuePath(
     componentDefinition,
     'defaultProps'
@@ -84,7 +84,10 @@ function getDefaultPropsPath(componentDefinition) {
   return defaultPropsPath;
 }
 
-function getDefaultValuesFromProps(properties, documentation) {
+function getDefaultValuesFromProps(
+  properties: NodePath,
+  documentation: Documentation
+) {
   properties
     .filter(propertyPath => types.Property.check(propertyPath.node))
     .forEach(function(propertyPath) {


### PR DESCRIPTION
Fixes https://github.com/reactjs/react-docgen/issues/69,

With this PR we first search for `defaultProps` of the stateless component (if stateless) and then check using `defaultProps` or `getDefaultProps`, it will overwrite the `defaultProps` of the stateless component if any is found.

Let me know what you think of it, this is my first time working with AST, so I'm prepared for all feedback 😅 .
