### PR TITLE
Verify that the MemberExpression that is being searched for belongs to the correct object

### DIFF
--- a/src/utils/__tests__/getMemberExpressionValuePath-test.js
+++ b/src/utils/__tests__/getMemberExpressionValuePath-test.js
@@ -32,6 +32,17 @@ describe('getMemberExpressionValuePath', () => {
         .toBe(def.parent.get('body', 1, 'expression', 'right'));
     });
 
+    it('takes the correct property definitions', () => {
+      var def = statement(`
+        var Foo = () => {};
+        Foo.propTypes = {};
+        Bar.propTypes = { unrelated: true };
+      `);
+
+      expect(getMemberExpressionValuePath(def, 'propTypes'))
+        .toBe(def.parent.get('body', 1, 'expression', 'right'));
+    });
+
     it('finds computed property definitions with literal keys', () => {
       var def = statement(`
         function Foo () {}

--- a/src/utils/getMemberExpressionValuePath.js
+++ b/src/utils/getMemberExpressionValuePath.js
@@ -11,6 +11,7 @@
  */
 
 import getNameOrValue from './getNameOrValue';
+import { String as toString } from './expressionTo';
 import recast from 'recast';
 
 var {types: {namedTypes: types}} = recast;
@@ -82,7 +83,8 @@ export default function getMemberExpressionValuePath(
 
       if (
         (!memberPath.node.computed || types.Literal.check(memberPath.node.property)) &&
-        getNameOrValue(memberPath.get('property')) === memberName
+        getNameOrValue(memberPath.get('property')) === memberName &&
+        toString(memberPath.get('object')) === localName
       ) {
         result = path.get('right');
         return false;


### PR DESCRIPTION
When searching for a MemberExpresion (i.e. "propTypes") that is defined
on an object (ArrowFunctionExpression, FunctionExpression,
FunctionDeclaration or VariableDeclaration), take the local Identifier
into account to find the member of the correct object.

Before:
When using multiple components per file, it would for every component
take the propTypes of the last component encountered.
```javascript
function Component1() { return (<i />); }
Component1.propTypes = { a: React.PropTypes.string };
function Component2() { return (<b />); }
Component2.propTypes = { b: React.PropTypes.number };
```

After:
Now it checks whether the property of the MemberExpression actually
belongs to the correct object.