### PR TITLE
Find nested MemberExpressions / resolve commonJS properties

### DIFF
--- a/src/utils/__tests__/getMemberExpressionValuePath-test.js
+++ b/src/utils/__tests__/getMemberExpressionValuePath-test.js
@@ -53,6 +53,48 @@ describe('getMemberExpressionValuePath', () => {
         .toBe(def.parent.get('body', 1, 'expression', 'right'));
     });
 
+    it('finds nested property definitions', () => {
+      var def = statement(`
+        module.exports.Foo = () => {};
+        module.exports.Foo.propTypes = {};
+      `);
+
+      expect(getMemberExpressionValuePath(def, 'propTypes'))
+        .toBe(def.parent.get('body', 1, 'expression', 'right'));
+    });
+
+    it('finds the correct nested property definitions', () => {
+      var def = statement(`
+        module.exports.Foo = () => {};
+        module.exports.Foo.propTypes = {};
+        exports.Foo.propTypes = {};
+      `);
+
+      expect(getMemberExpressionValuePath(def, 'propTypes'))
+        .toBe(def.parent.get('body', 1, 'expression', 'right'));
+    });
+
+    it('finds property definitions that are part of a commonJS export', () => {
+      var def = statement(`
+        function Foo () {}
+        module.exports.Foo.propTypes = {};
+        exports.Bar.propTypes = {};
+      `);
+
+      expect(getMemberExpressionValuePath(def, 'propTypes'))
+        .toBe(def.parent.get('body', 1, 'expression', 'right'));
+    });
+
+    it('ignores property definitions that don\'t belong to the object', () => {
+      var def = statement(`
+        function Foo () {}
+        module.bar.Foo.propTypes = {};
+        exports.Bar.propTypes = {};
+      `);
+
+      expect(getMemberExpressionValuePath(def, 'propTypes')).not.toBeDefined();
+    });
+
     it('ignores computed property definitions with expression', () => {
       var def = statement(`
         var Foo = function Bar() {};


### PR DESCRIPTION
When an object doesn't have a "local identifier", for example because
it is directly assigned to "module.exports", we still want to be able
to find the member that we are looking for (i.e. "propTypes").

Before:
When directly assigning a React Component to "(module.)exports", the
correct members (i.e. "propTypes") could not be found.

``` javascript
module.exports = function() { return (<i />); };
module.exports.propTypes = { a: PropTypes.string };
```

or

``` javascript
module.exports.Foo = function() { return (<i />); };
module.exports.Foo.propTypes = { b: PropTypes.number };
```

After applying this commit, the "getMemberExpressionValuePath" utility
method will be able to find members defined on the same object as the
component definition that has been passed in or tries to find the member
defined on "(module.)exports" but does not check (!) if the passed-in
component definition is also being exported / assigned to module.exports
