### PR TITLE
Force travis to use bigger machine / non-docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 language: node_js
 node_js:
   - 4


### PR DESCRIPTION
By setting "sudo: required" we force travis to use a bigger Ubuntu box
instead of running in a docker container.
See [travis documentation](https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments) for more information.

Relates to: #110