### PR TITLE
Resolve values in "oneOf" PropTypes

### DIFF
--- a/src/utils/__tests__/resolveToValue-test.js
+++ b/src/utils/__tests__/resolveToValue-test.js
@@ -137,4 +137,62 @@ describe('resolveToValue', () => {
 
   });
 
+  describe('MemberExpression', () => {
+
+    it('resolves a MemberExpression to it\'s init value', () => {
+      var path = parse([
+        'var foo = { bar: 1 };',
+        'foo.bar;',
+      ].join('\n'));
+
+      expect(resolveToValue(path).node).toEqualASTNode(builders.literal(1));
+    });
+
+    it('resolves a MemberExpression in the scope chain', () => {
+      var path = parse([
+        'var foo = 1;',
+        'var bar = { baz: foo };',
+        'bar.baz;',
+      ].join('\n'));
+
+      expect(resolveToValue(path).node).toEqualASTNode(builders.literal(1));
+    });
+
+    it('resolves a nested MemberExpression in the scope chain', () => {
+      var path = parse([
+        'var foo = { bar: 1 };',
+        'var bar = { baz: foo.bar };',
+        'bar.baz;',
+      ].join('\n'));
+
+      expect(resolveToValue(path).node).toEqualASTNode(builders.literal(1));
+    });
+
+    it('returns the last resolvable MemberExpression', () => {
+      var path = parse([
+        'import foo from "bar";',
+        'var bar = { baz: foo.bar };',
+        'bar.baz;',
+      ].join('\n'));
+
+      expect(resolveToValue(path).node).toEqualASTNode(
+        builders.memberExpression(
+          builders.identifier('foo'),
+          builders.identifier('bar')
+        )
+      );
+    });
+
+    it('returns the path itself if it can not resolve it any further', () => {
+      var path = parse([
+        'var foo = {};',
+        'foo.bar = 1;',
+        'foo.bar;',
+      ].join('\n'));
+
+      expect(resolveToValue(path).node).toEqualASTNode(path.node);
+    });
+
+  });
+
 });


### PR DESCRIPTION
This will allow the propTypesHandler generate better results for "oneOf" propTypes.
This change is made in two commits, the first one will enable the `resolveToValue` method
to resolve `MeberExpression`s to their initialization value and the second one will
use that to find the value of all Identifiers inside a `oneOf` propType.

Before:
```javascript
var TYPES = ["FOO", "BAR"];
PropTypes.oneOf(TYPES);
```
would print this as "custom".
Also
```javascript
var TYPES = { FOO: "FOO", BAR: "BAR" };
PropTypes.oneOf([TYPES.FOO, TYPES.BAR]);
```
would resolve to two values, but both are reported as computed custom values.

After:
Now the propTypesHandler will be able to resolve most of the common patterns that resolve to
static values inside the same module.