### PR TITLE
Add support for newly introduced PropTypes "symbol"

### DIFF
--- a/src/utils/__tests__/getPropType-test.js
+++ b/src/utils/__tests__/getPropType-test.js
@@ -32,6 +32,7 @@ describe('getPropType', () => {
       'any',
       'element',
       'node',
+      'symbol',
     ];
 
     simplePropTypes.forEach(

--- a/src/utils/getPropType.js
+++ b/src/utils/getPropType.js
@@ -108,6 +108,7 @@ var simplePropTypes = {
   any: 1,
   element: 1,
   node: 1,
+  symbol: 1,
 };
 
 var propTypes = {


### PR DESCRIPTION
React has introduced a new primitive PropType "symbol".
https://github.com/facebook/react/pull/6377
This change adds support for that propType so that it is not reported
as "custom".