### PR TITLE
Make resolveToValue consider assignments to identifiers (fixes #58)

### DIFF
--- a/bin/__tests__/react-docgen-test.js
+++ b/bin/__tests__/react-docgen-test.js
@@ -8,13 +8,14 @@
  *
  */
 
-/*global jasmine, jest, describe, it, expect, afterEach*/
+/*global jasmine, describe, it, expect, afterEach*/
+
+// NOTE: This test spawns a subprocesses that load the files from dist/, not
+// src/. Before running this test run `npm run build` or `npm run watch`.
 
 const TEST_TIMEOUT = 120000;
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = TEST_TIMEOUT;
-
-jest.disableAutomock();
 
 var fs = require('fs');
 var path = require('path');
@@ -96,8 +97,8 @@ describe('react-docgen CLI', () => {
 
   it('reads from stdin', () => {
     return run([], component).then(([stdout, stderr]) => {
-      expect(stdout.length > 0).toBe(true);
-      expect(stderr.length).toBe(0);
+      expect(stdout).not.toBe('');
+      expect(stderr).toBe('');
     });
   }, TEST_TIMEOUT);
 
@@ -238,7 +239,6 @@ describe('react-docgen CLI', () => {
           '--resolver='+path.join(__dirname, './example/customResolver.js'),
           path.join(__dirname, '../../example/components/Component.js'),
         ]).then(([stdout, stderr]) => {
-          console.log(stderr);
           expect(stdout).toContain('Custom');
         }),
       ]);

--- a/package.json
+++ b/package.json
@@ -58,8 +58,6 @@
       "bin",
       "src"
     ],
-    "testPathIgnorePatterns": [
-      "/bin/__tests__/example/"
-    ]
+    "testRegex": "/__tests__/.*-test\\.js$"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "babel-cli": "^6.9.0",
     "babel-eslint": "^6.0.4",
-    "babel-jest": "^14.1.0",
+    "babel-jest": "^15.0.0",
     "babel-plugin-syntax-flow": "^6.8.0",
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-plugin-transform-runtime": "^6.9.0",
@@ -48,7 +48,7 @@
     "cross-spawn": "^4.0.0",
     "eslint": "^3.2.2",
     "flow-bin": "^0.31.0",
-    "jest-cli": "^14.1.0",
+    "jest-cli": "^15.1.1",
     "rimraf": "^2.3.2",
     "temp": "^0.8.1"
   },
@@ -60,13 +60,6 @@
     ],
     "testPathIgnorePatterns": [
       "/bin/__tests__/example/"
-    ],
-    "unmockedModulePathPatterns": [
-      "node_modules",
-      "tests/utils",
-      "recast",
-      "babel",
-      "babylon"
     ]
   }
 }

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -1,0 +1,7 @@
+exports[`main fixtures processes component "component_1.js" without errors 1`] = `
+Object {
+  "description": "The is a component to test the document generation",
+  "displayName": "Component",
+  "methods": Array []
+}
+`;

--- a/src/__tests__/fixtures/component_1.js
+++ b/src/__tests__/fixtures/component_1.js
@@ -1,0 +1,12 @@
+var Component, React;
+
+React = require('react');
+
+/**
+ * The is a component to test the document generation
+ */
+Component = React.createClass({
+    displayName: 'Component',
+});
+
+module.exports = Component;

--- a/src/__tests__/main-test.js
+++ b/src/__tests__/main-test.js
@@ -8,17 +8,15 @@
  *
  */
 
-/*global jest, describe, beforeEach, it, expect*/
+/*global describe, it, expect*/
 
-jest.disableAutomock();
+import fs from 'fs';
+import path from 'path';
+
+import * as docgen from '../main';
+import {ERROR_MISSING_DEFINITION} from '../parse';
 
 describe('main', () => {
-  var docgen, ERROR_MISSING_DEFINITION;
-
-  beforeEach(() => {
-    docgen = require('../main');
-    ({ERROR_MISSING_DEFINITION} = require('../parse'));
-  });
 
   function test(source) {
     it('parses with default resolver/handlers', () => {
@@ -224,5 +222,18 @@ describe('main', () => {
 
       expect(() => docgen.parse(source)).toThrowError(ERROR_MISSING_DEFINITION);
     });
+  });
+
+  describe('fixtures', () => {
+    const fixturePath = path.join(__dirname, 'fixtures');
+    const fileNames = fs.readdirSync(fixturePath);
+    for (let i = 0; i < fileNames.length; i++) {
+      const fileContent = fs.readFileSync(path.join(fixturePath, fileNames[i]));
+
+      it(`processes component "${fileNames[i]}" without errors`, () => {
+        expect(() => docgen.parse(fileContent)).not.toThrowError();
+        expect(docgen.parse(fileContent)).toMatchSnapshot();
+      });
+    }
   });
 });

--- a/src/handlers/__tests__/componentMethodsJsDocHandler-test.js
+++ b/src/handlers/__tests__/componentMethodsJsDocHandler-test.js
@@ -8,17 +8,16 @@
  *
  */
 
-/*global jest, describe, beforeEach, it, expect*/
+/*global describe, beforeEach, it, expect*/
 
-jest.disableAutomock();
+import Documentation from '../../Documentation';
+import componentMethodsJsDocHandler from '../componentMethodsJsDocHandler';
 
 describe('componentMethodsHandler', () => {
   let documentation;
-  let componentMethodsJsDocHandler;
 
   beforeEach(() => {
-    documentation = new (require('../../Documentation'));
-    componentMethodsJsDocHandler = require('../componentMethodsJsDocHandler').default;
+    documentation = new Documentation();
   });
 
   it('stays the same when no docblock is present', () => {

--- a/src/handlers/__tests__/propTypeHandler-test.js
+++ b/src/handlers/__tests__/propTypeHandler-test.js
@@ -10,23 +10,20 @@
 
 /*global jest, describe, it, expect, beforeEach*/
 
-jest.disableAutomock();
 jest.mock('../../Documentation');
+jest.mock('../../utils/getPropType', () => jest.fn(() => ({})));
+
+import {statement, expression} from '../../../tests/utils';
+import Documentation from '../../Documentation';
+import propTypeHandler from '../propTypeHandler';
 
 describe('propTypeHandler', () => {
-  var statement, expression;
   var getPropTypeMock;
   var documentation;
-  var propTypeHandler;
 
   beforeEach(() => {
-    ({statement, expression} = require('../../../tests/utils'));
-    getPropTypeMock = jest.genMockFunction().mockImplementation(() => ({}));
-    jest.setMock('../../utils/getPropType', getPropTypeMock);
-    jest.mock('../../utils/getPropType');
-
-    documentation = new (require('../../Documentation'));
-    propTypeHandler = require('../propTypeHandler').default;
+    getPropTypeMock = require('../../utils/getPropType');
+    documentation = new Documentation();
   });
 
   function template(src) {

--- a/src/resolver/__tests__/findAllComponentDefinitions-test.js
+++ b/src/resolver/__tests__/findAllComponentDefinitions-test.js
@@ -8,27 +8,20 @@
  *
  */
 
-/*global jest, describe, beforeEach, it, expect*/
+/*global describe, it, expect*/
 
-jest.disableAutomock();
+import recast from 'recast';
+import * as utils from '../../../tests/utils';
+import findAllComponentDefinitions from '../findAllComponentDefinitions';
 
 describe('findAllComponentDefinitions', () => {
-  var findAllComponentDefinitions;
-  var recast;
-  var utils;
 
   function parse(source) {
     return findAllComponentDefinitions(
-      utils.parse(source),
+      utils.parse(source, recast),
       recast
     );
   }
-
-  beforeEach(() => {
-    findAllComponentDefinitions = require('../findAllComponentDefinitions').default;
-    utils = require('../../../tests/utils');
-    recast = require('recast');
-  });
 
   describe('React.createClass', () => {
 

--- a/src/resolver/__tests__/findAllExportedComponentDefinitions-test.js
+++ b/src/resolver/__tests__/findAllExportedComponentDefinitions-test.js
@@ -8,15 +8,13 @@
  *
  */
 
-/*global jest, describe, beforeEach, it, expect*/
+/*global describe, it, expect*/
+import recast from 'recast';
+import * as utils from '../../../tests/utils';
 
-jest.disableAutomock();
+import findAllExportedComponentDefinitions from '../findAllExportedComponentDefinitions';
 
 describe('findAllExportedComponentDefinitions', () => {
-  var findAllExportedComponentDefinitions;
-  var utils;
-  var recast;
-
   function parse(source) {
     return utils.parse(source);
   }
@@ -24,13 +22,6 @@ describe('findAllExportedComponentDefinitions', () => {
   function findComponents(path) {
     return findAllExportedComponentDefinitions(path, recast);
   }
-
-  beforeEach(() => {
-    findAllExportedComponentDefinitions =
-      require('../findAllExportedComponentDefinitions').default;
-    utils = require('../../../tests/utils');
-    recast = require('recast');
-  });
 
   describe('CommonJS module exports', () => {
 

--- a/src/resolver/__tests__/findExportedComponentDefinition-test.js
+++ b/src/resolver/__tests__/findExportedComponentDefinition-test.js
@@ -8,28 +8,19 @@
  *
  */
 
-/*global jest, describe, beforeEach, it, expect*/
+/*global describe, it, expect*/
 
-jest.disableAutomock();
+import recast from 'recast';
+import * as utils from '../../../tests/utils';
+import findExportedComponentDefinition from '../findExportedComponentDefinition';
 
 describe('findExportedComponentDefinition', () => {
-  var findExportedComponentDefinition;
-  var utils;
-  var recast;
-
   function parse(source) {
     return findExportedComponentDefinition(
       utils.parse(source),
       recast
     );
   }
-
-  beforeEach(() => {
-    findExportedComponentDefinition =
-      require('../findExportedComponentDefinition').default;
-    utils = require('../../../tests/utils');
-    recast = require('recast');
-  });
 
   describe('CommonJS module exports', () => {
 

--- a/src/utils/__tests__/docblock-test.js
+++ b/src/utils/__tests__/docblock-test.js
@@ -8,20 +8,17 @@
  *
  */
 
-/*global jest, describe, beforeEach, it, expect*/
-var os = require('os');
-var EOL = os.EOL;
+/*global describe, it, expect*/
+import os from 'os';
+import {statement} from '../../../tests/utils';
 
-jest.unmock('../docblock');
+import {getDoclets, getDocblock} from '../docblock';
+
+const EOL = os.EOL;
 
 describe('docblock', () => {
 
   describe('getDoclets', () => {
-    let getDoclets;
-
-    beforeEach(() => {
-      ({getDoclets} = require('../docblock'));
-    });
 
     it('extracts single line doclets', () => {
       expect(getDoclets('@foo bar\n@bar baz'))
@@ -37,6 +34,7 @@ describe('docblock', () => {
       expect(getDoclets('@foo bar\nbaz\n@abc\n@bar baz'))
         .toEqual({foo: 'bar\nbaz', abc: true, bar: 'baz'});
     });
+
   });
 
   describe('getDocblock', () => {
@@ -48,14 +46,6 @@ describe('docblock', () => {
       ' */',
       'foo;',
     ];
-
-    let getDocblock;
-    let statement;
-
-    beforeEach(() => {
-      ({getDocblock} = require('../docblock'));
-      ({statement} = require('../../../tests/utils'));
-    });
 
     it('gets the closest docblock of the given node', () => {
       let node = statement(source.join(EOL));

--- a/src/utils/__tests__/getMemberExpressionRoot-test.js
+++ b/src/utils/__tests__/getMemberExpressionRoot-test.js
@@ -8,17 +8,17 @@
  *
  */
 
-/*global jest, describe, it, expect*/
+/*global describe, it, expect*/
 
 import {expression} from '../../../tests/utils';
 
-jest.unmock('../getMemberExpressionRoot');
-
-var getMemberExpressionRoot = require('../getMemberExpressionRoot').default;
+import getMemberExpressionRoot from '../getMemberExpressionRoot';
 
 describe('getMemberExpressionRoot', () => {
+
   it('returns the root of a member expression', () => {
     var root = getMemberExpressionRoot(expression('foo.bar.baz'));
     expect(root.node).toEqualASTNode(expression('foo').node);
   });
+
 });

--- a/src/utils/__tests__/getMemberValuePath-test.js
+++ b/src/utils/__tests__/getMemberValuePath-test.js
@@ -8,21 +8,20 @@
  *
  */
 
-/*global jest, describe, beforeEach, it, expect*/
+/*global jest, describe, it, expect*/
 
-jest.unmock('../getMemberValuePath');
+jest.mock('../getPropertyValuePath');
+jest.mock('../getClassMemberValuePath');
+
+import {expression, statement} from '../../../tests/utils';
+
+import getPropertyValuePath from '../getPropertyValuePath';
+import getClassMemberValuePath from '../getClassMemberValuePath';
+import getMemberValuePath from '../getMemberValuePath';
 
 describe('getMemberValuePath', () => {
-  var getMemberValuePath;
-  var expression, statement;
-
-  beforeEach(() => {
-    ({expression, statement} = require('../../../tests/utils'));
-    getMemberValuePath = require('../getMemberValuePath').default;
-  });
 
   it('handles ObjectExpresisons', () => {
-    var getPropertyValuePath = require('../getPropertyValuePath').default;
     var path = expression('{}');
 
     getMemberValuePath(path, 'foo');
@@ -30,7 +29,6 @@ describe('getMemberValuePath', () => {
   });
 
   it('handles ClassDeclarations', () => {
-    var getClassMemberValuePath = require('../getClassMemberValuePath').default;
     var path = statement('class Foo {}');
 
     getMemberValuePath(path, 'foo');
@@ -38,7 +36,6 @@ describe('getMemberValuePath', () => {
   });
 
   it('handles ClassExpressions', () => {
-    var getClassMemberValuePath = require('../getClassMemberValuePath').default;
     var path = expression('class {}');
 
     getMemberValuePath(path, 'foo');
@@ -46,8 +43,6 @@ describe('getMemberValuePath', () => {
   });
 
   it('tries synonyms', () => {
-    var getPropertyValuePath = require('../getPropertyValuePath').default;
-    var getClassMemberValuePath = require('../getClassMemberValuePath').default;
     var path = expression('{}');
 
     getMemberValuePath(path, 'defaultProps');
@@ -62,8 +57,6 @@ describe('getMemberValuePath', () => {
   });
 
   it('returns the result of getPropertyValuePath and getClassMemberValuePath', () => {
-    var getPropertyValuePath = require('../getPropertyValuePath').default;
-    var getClassMemberValuePath = require('../getClassMemberValuePath').default;
     getPropertyValuePath.mockReturnValue(42);
     getClassMemberValuePath.mockReturnValue(21);
     var path = expression('{}');
@@ -74,4 +67,5 @@ describe('getMemberValuePath', () => {
 
     expect(getMemberValuePath(path, 'defaultProps')).toBe(21);
   });
+
 });

--- a/src/utils/__tests__/normalizeClassDefinition-test.js
+++ b/src/utils/__tests__/normalizeClassDefinition-test.js
@@ -8,13 +8,7 @@
  *
  */
 
-/*global jest, describe, beforeEach, it, expect*/
-
-jest
-  .unmock('../normalizeClassDefinition')
-  .unmock('../getMemberExpressionRoot')
-  .unmock('../getMembers');
-
+/*global describe, beforeEach, it, expect*/
 
 describe('normalizeClassDefinition', () => {
   var parse;

--- a/src/utils/__tests__/resolveExportDeclaration-test.js
+++ b/src/utils/__tests__/resolveExportDeclaration-test.js
@@ -10,20 +10,18 @@
 
 /*global jest, describe, beforeEach, it, expect*/
 
+jest.mock('../resolveToValue');
+
 import { statement } from '../../../tests/utils';
 
-jest.unmock('../resolveExportDeclaration');
-
+import resolveToValue from '../resolveToValue';
+import resolveExportDeclaration from '../resolveExportDeclaration';
 
 describe('resolveExportDeclaration', () => {
   var returnValue = {};
-  var resolveToValue;
-  var resolveExportDeclaration;
 
   beforeEach(() => {
-    resolveToValue = require('../resolveToValue').default;
     resolveToValue.mockReturnValue(returnValue);
-    resolveExportDeclaration = require('../resolveExportDeclaration').default;
   });
 
   it('resolves default exports', () => {

--- a/src/utils/__tests__/resolveToValue-test.js
+++ b/src/utils/__tests__/resolveToValue-test.js
@@ -91,6 +91,18 @@ describe('resolveToValue', () => {
       .toBe('FunctionDeclaration');
   });
 
+  describe('assignments', () => {
+    it('resolves to assigned values', () => {
+      var path = parse([
+        'var foo;',
+        'foo = 42;',
+        'foo;',
+      ].join('\n'));
+
+      expect(resolveToValue(path).node).toEqualASTNode(builders.literal(42));
+    });
+  });
+
   describe('ImportDeclaration', () => {
 
     it('resolves default import references to the import declaration', () => {

--- a/src/utils/__tests__/resolveToValue-test.js
+++ b/src/utils/__tests__/resolveToValue-test.js
@@ -8,26 +8,20 @@
  *
  */
 
-/*global jest, describe, beforeEach, it, expect*/
+/*global describe, it, expect*/
 
-jest.disableAutomock();
+import recast from 'recast';
+
+const builders = recast.types.builders;
+import resolveToValue from  '../resolveToValue';
+import * as utils from '../../../tests/utils';
 
 describe('resolveToValue', () => {
-  var builders;
-  var utils;
-  var resolveToValue;
 
   function parse(src) {
     var root = utils.parse(src);
     return root.get('body', root.node.body.length - 1, 'expression');
   }
-
-  beforeEach(() => {
-    var recast = require('recast');
-    builders = recast.types.builders;
-    resolveToValue = require('../resolveToValue').default;
-    utils = require('../../../tests/utils');
-  });
 
   it('resolves simple variable declarations', () => {
     var path = parse([

--- a/src/utils/traverse.js
+++ b/src/utils/traverse.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ *
+ */
+
+'use strict';
+
+type Visitor = (path: NodePath) => any;
+
+import recast from 'recast';
+
+/**
+ * A helper function that doesn't traverse into nested blocks / statements by
+ * default.
+ */
+export function traverseShallow(
+  ast: ASTNode,
+  visitors: ({[key: string]: Visitor})
+): void {
+  recast.visit(ast, {...defaultVisitors, ...visitors});
+}
+
+const ignore = () => false;
+const defaultVisitors = {
+  visitFunctionDeclaration: ignore,
+  visitFunctionExpression: ignore,
+  visitClassDeclaration: ignore,
+  visitClassExpression: ignore,
+  visitIfStatement: ignore,
+  visitWithStatement: ignore,
+  visitSwitchStatement: ignore,
+  visitWhileStatement: ignore,
+  visitDoWhileStatement: ignore,
+  visitForStatement: ignore,
+  visitForInStatement: ignore,
+  visitForOfStatement: ignore,
+  visitExportDeclaration: ignore,
+  visitExportNamedDeclaration: ignore,
+  visitExportDefaultDeclaration: ignore,
+  visitConditionalExpression: ignore,
+};


### PR DESCRIPTION
In the following example, resolveToValue wouldn't resolve to the value
assigned to "React" because it only looks at the variable
definition, not at assignments to the variable:

```
var React;
React = require('react');
module.exports = React.createClass(...);
```

This diff fixes that. It will make a shallow traversal over the scope
where the variable is defined and look for the last assignment to the
variable.

---

I'm also trying to improve tests by storing component definitions that
are known to have been broken in `src/__tests__/fixtures/`. Adding more
components over time will strengthen the test suit and help catch
regressions.

Also updates to jest v15.