### PR TITLE
Fixed infinite loop in utils/isStatelessComponent.js

### DIFF
--- a/src/__tests__/fixtures/component_2.js
+++ b/src/__tests__/fixtures/component_2.js
@@ -21,3 +21,7 @@ export class Button extends React.Component {
     };
   }
 }
+
+export function foo() {
+  return [].join();
+}

--- a/src/utils/isStatelessComponent.js
+++ b/src/utils/isStatelessComponent.js
@@ -94,6 +94,9 @@ function returnsJSXElementOrReactCreateElementCall(path) {
           else {
             while (calleeValue.get('object').node.type !== 'Identifier') {
               calleeValue = calleeValue.get('object');
+              if (calleeValue.node.type === 'ArrayExpression') {
+                break;
+              }
               namesToResolve.unshift(calleeValue.get('property'));
             }
 

--- a/src/utils/isStatelessComponent.js
+++ b/src/utils/isStatelessComponent.js
@@ -88,15 +88,14 @@ function returnsJSXElementOrReactCreateElementCall(path) {
         let namesToResolve = [calleeValue.get('property')];
 
         if (calleeValue.node.type === 'MemberExpression') {
-          if (calleeValue.get('object').node.type === 'Identifier') {
+          const calleeType = calleeValue.get('object').node.type;
+          if (calleeType === 'Identifier') {
             resolvedValue = resolveToValue(calleeValue.get('object'));
           }
-          else {
+          // prevent infinite loop with array literals
+          else if (calleeType !== 'ArrayExpression') {
             while (calleeValue.get('object').node.type !== 'Identifier') {
               calleeValue = calleeValue.get('object');
-              if (calleeValue.node.type === 'ArrayExpression') {
-                break;
-              }
               namesToResolve.unshift(calleeValue.get('property'));
             }
 


### PR DESCRIPTION
Parsing a file that contains anything like below will result in react-docgen hanging:

```jsx
export function foo() {
  return [].join();
}
```

I haven't had a chance to dig into this yet, but we've been bitten by this.