### PR TITLE
Add __mocks__ folder to default ignoreDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Options:
    --pretty              pretty print JSON
    -x, --extension       File extensions to consider. Repeat to define multiple extensions. Default:  [js,jsx]
    -e, --exclude         Filename pattern to exclude. Default:  []
-   -i, --ignore          Folders to ignore. Default:  [node_modules,__tests__]
+   -i, --ignore          Folders to ignore. Default:  [node_modules,__tests__,__mocks__]
    --resolver RESOLVER   Resolver name (findAllComponentDefinitions, findExportedComponentDefinition) or
       path to a module that exports a resolver.  [findExportedComponentDefinition]
 

--- a/bin/__tests__/react-docgen-test.js
+++ b/bin/__tests__/react-docgen-test.js
@@ -153,9 +153,10 @@ describe('react-docgen CLI', () => {
     ]);
   }, TEST_TIMEOUT);
 
-  it('ignores files in node_modules and __tests__ by default', () => {
+  it('ignores files in node_modules, __tests__ and __mocks__ by default', () => {
     createTempfiles(null, 'node_modules');
     createTempfiles(null, '__tests__');
+    createTempfiles(null, '__mocks__');
 
     return run([tempDir]).then(([stdout, stderr]) => {
       expect(stdout).toBe('');

--- a/bin/react-docgen.js
+++ b/bin/react-docgen.js
@@ -49,7 +49,7 @@ var argv = require('nomnom')
       full: 'ignore',
       help: 'Folders to ignore. Default:',
       list: true,
-      default: ['node_modules', '__tests__'],
+      default: ['node_modules', '__tests__', '__mocks__'],
     },
     resolver: {
       help: 'Resolver name (findAllComponentDefinitions, findExportedComponentDefinition) or path to a module that exports a resolver.',


### PR DESCRIPTION
As __mocks__ is used in manual mocks on jest
cf. https://facebook.github.io/jest/docs/manual-mocks.html