### PR TITLE
Guard against infinite loop on chained or static methods

### DIFF
--- a/src/__tests__/fixtures/component_2.js
+++ b/src/__tests__/fixtures/component_2.js
@@ -21,3 +21,11 @@ export class Button extends React.Component {
     };
   }
 }
+
+export function foo() {
+  return [].join();
+}
+
+export function chained() {
+  return foo.bar().join();
+}

--- a/src/__tests__/fixtures/component_2.js
+++ b/src/__tests__/fixtures/component_2.js
@@ -29,3 +29,7 @@ export function foo() {
 export function chained() {
   return foo.bar().join();
 }
+
+export function templateLiteral() {
+  return `foo bar`.split(' ');
+}

--- a/src/utils/isStatelessComponent.js
+++ b/src/utils/isStatelessComponent.js
@@ -27,6 +27,15 @@ const validPossibleStatelessComponentTypes = [
   'ArrowFunctionExpression',
 ];
 
+function isValidCalleeType(type) {
+  return [
+    'Identifier',
+    'CallExpression',
+    'ArrayExpression',
+    'Literal'
+  ].indexOf(type) < 0;
+}
+
 function isJSXElementOrReactCreateElement(path) {
   return (
     path.node.type === 'JSXElement' ||
@@ -92,7 +101,7 @@ function returnsJSXElementOrReactCreateElementCall(path) {
             resolvedValue = resolveToValue(calleeValue.get('object'));
           }
           else {
-            while (calleeValue.get('object').node.type !== 'Identifier') {
+            while (isValidCalleeType(calleeValue.get('object').node.type)) {
               calleeValue = calleeValue.get('object');
               namesToResolve.unshift(calleeValue.get('property'));
             }

--- a/src/utils/isStatelessComponent.js
+++ b/src/utils/isStatelessComponent.js
@@ -32,6 +32,7 @@ function isValidCalleeType(type) {
     'Identifier',
     'CallExpression',
     'ArrayExpression',
+    'TemplateLiteral'
     'Literal'
   ].indexOf(type) < 0;
 }

--- a/src/utils/isStatelessComponent.js
+++ b/src/utils/isStatelessComponent.js
@@ -32,7 +32,7 @@ function isValidCalleeType(type) {
     'Identifier',
     'CallExpression',
     'ArrayExpression',
-    'TemplateLiteral'
+    'TemplateLiteral',
     'Literal'
   ].indexOf(type) < 0;
 }


### PR DESCRIPTION
### Summary
  * Fixes https://github.com/reactjs/react-docgen/issues/136
  * Add `isValidCalleeType()` check for CallExpresion and ArrayExpression and Literal
  * Improves on https://github.com/reactjs/react-docgen/pull/134 by validating the `calleeValue`'s object type, which happens to be mutated in-place during the `while` loop.
