### PR TITLE
Replace nomnom with commanderjs

### DIFF
--- a/bin/react-docgen.js
+++ b/bin/react-docgen.js
@@ -17,35 +17,36 @@ function collect(val, memo) {
 }
 
 argv
+    .usage('[path...] [options]')
+    .description(
+        'Extract meta information from React components.\n' +
+        '  If a directory is passed, it is recursively traversed.')
     .option(
-        '--path <PATH>',
-        'A component file or directory. If no path is provided, it reads from stdin.', collect, [])
-    .option(
-        '-o, --out <FILE>',
+        '-o, --out <file>',
         'Store extracted information in the FILE')
     .option(
         '--pretty',
         'pretty print JSON')
     .option(
-        '-x, --extension <EXTENSION>',
+        '-x, --extension <extension>',
         'File extensions to consider. Repeat to define multiple extensions. Default: js, jsx',
         collect,
         ['js', 'jsx'])
     .option(
-        '-e, --exclude <PATH>',
+        '-e, --exclude <path>',
         'Filename pattern to exclude.',
         collect,
         [])
     .option(
-        '-i, --ignore <PATH>',
+        '-i, --ignore <path>',
         'Folders to ignore',
         collect,
         ['node_modules', '__tests__', '__mocks__'])
     .option(
-        '--resolver <RESOLVER>',
+        '--resolver <resolver>',
         'Resolver name (findAllComponentDefinitions, findExportedComponentDefinition) or path to a module that exports a resolver.',
         'findExportedComponentDefinition')
-    .arguments('[FILES]');
+    .arguments('<path>');
 
 argv.parse(process.argv);
 

--- a/bin/react-docgen.js
+++ b/bin/react-docgen.js
@@ -9,55 +9,45 @@
  *
  */
 
-var argv = require('nomnom')
-  .script('react-docgen')
-  .help(
-    'Extract meta information from React components.\n' +
-    'If a directory is passed, it is recursively traversed.'
-  )
-  .options({
-    path: {
-      position: 0,
-      help: 'A component file or directory. If no path is provided it reads from stdin.',
-      metavar: 'PATH',
-      list: true,
-    },
-    out: {
-      abbr: 'o',
-      help: 'store extracted information in FILE',
-      metavar: 'FILE',
-    },
-    pretty: {
-      help: 'pretty print JSON',
-      flag: true,
-    },
-    extension: {
-      abbr: 'x',
-      help: 'File extensions to consider. Repeat to define multiple extensions. Default:',
-      list: true,
-      default: ['js', 'jsx'],
-    },
-    excludePatterns: {
-      abbr: 'e',
-      full: 'exclude',
-      help: 'Filename pattern to exclude. Default:',
-      list: true,
-      default: [],
-    },
-    ignoreDir: {
-      abbr: 'i',
-      full: 'ignore',
-      help: 'Folders to ignore. Default:',
-      list: true,
-      default: ['node_modules', '__tests__', '__mocks__'],
-    },
-    resolver: {
-      help: 'Resolver name (findAllComponentDefinitions, findExportedComponentDefinition) or path to a module that exports a resolver.',
-      metavar: 'RESOLVER',
-      default: 'findExportedComponentDefinition',
-    },
-  })
-  .parse();
+var argv = require('commander');
+
+function collect(val, memo) {
+  memo.push(val);
+  return memo;
+}
+
+argv
+    .option(
+        '--path <PATH>',
+        'A component file or directory. If no path is provided, it reads from stdin.', collect, [])
+    .option(
+        '-o, --out <FILE>',
+        'Store extracted information in the FILE')
+    .option(
+        '--pretty',
+        'pretty print JSON')
+    .option(
+        '-x, --extension <EXTENSION>',
+        'File extensions to consider. Repeat to define multiple extensions. Default: js, jsx',
+        collect,
+        ['js', 'jsx'])
+    .option(
+        '-e, --exclude <PATH>',
+        'Filename pattern to exclude.',
+        collect,
+        [])
+    .option(
+        '-i, --ignore <PATH>',
+        'Folders to ignore',
+        collect,
+        ['node_modules', '__tests__', '__mocks__'])
+    .option(
+        '--resolver <RESOLVER>',
+        'Resolver name (findAllComponentDefinitions, findExportedComponentDefinition) or path to a module that exports a resolver.',
+        'findExportedComponentDefinition')
+    .arguments('[FILES]');
+
+argv.parse(process.argv);
 
 var async = require('async');
 var dir = require('node-dir');
@@ -66,10 +56,10 @@ var parser = require('../dist/main');
 var path = require('path');
 
 var output = argv.out;
-var paths = argv.path || [];
+var paths = argv.args || [];
 var extensions = new RegExp('\\.(?:' + argv.extension.join('|') + ')$');
-var ignoreDir = argv.ignoreDir;
-var excludePatterns = argv.excludePatterns;
+var ignoreDir = argv.ignore;
+var excludePatterns = argv.exclude;
 var resolver;
 var errorMessage;
 

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "async": "^1.4.2",
     "babel-runtime": "^6.9.2",
     "babylon": "~5.8.3",
+    "commander": "^2.9.0",
     "doctrine": "^1.2.0",
     "node-dir": "^0.1.10",
-    "nomnom": "^1.8.1",
     "recast": "^0.11.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #56 

This is a pretty straight port over to commander.

Benefits:
- Removes dependency on a dead package.
- Commander only has one dependency: graceful-readlink, making install times just a tiny tiny bit faster ;)