### PR TITLE
Ignore SpreadProperties in shapes

### DIFF
--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -71,6 +71,19 @@ Object {
         "value": "Child.propTypes",
       },
     },
+    "extendedChild": Object {
+      "description": "",
+      "required": true,
+      "type": Object {
+        "name": "shape",
+        "value": Object {
+          "adopted": Object {
+            "name": "bool",
+            "required": true,
+          },
+        },
+      },
+    },
     "something": Object {
       "description": "",
       "required": true,

--- a/src/__tests__/fixtures/component_4.js
+++ b/src/__tests__/fixtures/component_4.js
@@ -19,8 +19,12 @@ var pt = React.PropTypes;
 class Parent extends React.Component {
   static propTypes = {
     something: pt.string.isRequired,
-    child: pt.shape(Child.propTypes).isRequired
-  }
+    child: pt.shape(Child.propTypes).isRequired,
+    extendedChild: pt.shape({
+      ...Child.propTypes,
+      adopted: pt.bool.isRequired
+    }).isRequired
+  };
 }
 
 export default Parent;

--- a/src/utils/getPropType.js
+++ b/src/utils/getPropType.js
@@ -112,6 +112,11 @@ function getPropTypeShape(argumentPath) {
   if (types.ObjectExpression.check(argumentPath.node)) {
     var value = {};
     argumentPath.get('properties').each(function(propertyPath) {
+      if (propertyPath.get('type').value === types.SpreadProperty.name) {
+        // It is impossible to resolve a name for a spreadproperty
+        return;
+      }
+
       var descriptor: PropDescriptor | PropTypeDescriptor =
         getPropType(propertyPath.get('value'));
       var docs = getDocblock(propertyPath);


### PR DESCRIPTION
Prevent react-docgen from crashing when spread operations are passed to shape(). Behaviour is similar to how spread operations are handled in normal propType definitions.