### PR TITLE
[issue] Illustrate a syntax error with ES2016

### DIFF
--- a/src/__tests__/fixtures/component_5.js
+++ b/src/__tests__/fixtures/component_5.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+const RANDOM_VALUE = 2 ** 2;
+
 const Button = ({ children, onClick, style = {} }) => (
   <button
     style={{ }}


### PR DESCRIPTION
> 
      SyntaxError: Unexpected token (3:24)      
          at Parser.pp.raise (node_modules/babylon/lib/parser/location.js:24:13)
          at Parser.pp.unexpected (node_modules/babylon/lib/parser/util.js:82:8)
          at Parser.pp.parseExprAtom (node_modules/babylon/lib/parser/expression.js:425:12)

I'm not sure where to start to address that issue.
Here is the proposal for reference https://github.com/rwaldron/exponentiation-operator.
