### PR TITLE
Fix tests: Do not export component twice

### DIFF
--- a/src/__tests__/fixtures/component_2.js
+++ b/src/__tests__/fixtures/component_2.js
@@ -34,7 +34,7 @@ export function templateLiteral() {
   return `foo bar`.split(' ');
 }
 
-export default function withThis() {
+export function withThis() {
   return this.foo();
 }
 

--- a/src/resolver/__tests__/findAllExportedComponentDefinitions-test.js
+++ b/src/resolver/__tests__/findAllExportedComponentDefinitions-test.js
@@ -826,7 +826,7 @@ describe('findAllExportedComponentDefinitions', () => {
             import React from 'React';
             var ComponentA = class extends React.Component {};
             var ComponentB = class extends React.Component {};
-            export {ComponentA, ComponentA};
+            export {ComponentA as foo, ComponentA as bar};
           `);
           var actual = findComponents(parsed);
 
@@ -903,7 +903,7 @@ describe('findAllExportedComponentDefinitions', () => {
             import React from 'React';
             var ComponentA = () => <div />;
             var ComponentB = () => <div />;
-            export {ComponentA, ComponentA};
+            export {ComponentA as foo, ComponentA as bar};
           `);
           var actual = findComponents(parsed);
 

--- a/src/resolver/__tests__/findExportedComponentDefinition-test.js
+++ b/src/resolver/__tests__/findExportedComponentDefinition-test.js
@@ -470,7 +470,7 @@ describe('findExportedComponentDefinition', () => {
 
           source = `
             var R = require("React");
-            export var ComponentA = R.createClass({}),
+            export var ComponentA = R.createClass({});
             var ComponentB = R.createClass({});
             export {ComponentB};
           `;
@@ -665,7 +665,7 @@ describe('findExportedComponentDefinition', () => {
         it('errors if multiple components are exported', () => {
           var source = `
             var R = require("React");
-            var ComponentA = R.createClass({}),
+            var ComponentA = R.createClass({});
             var ComponentB = R.createClass({});
             export {ComponentA as foo, ComponentB};
           `;


### PR DESCRIPTION
Exporting the same identifier twice is not allowed by spec
This will throw with babylon >=6 and maybe other parsers