### PR TITLE
Add developit/proptypes to allowed module names

### DIFF
--- a/src/utils/isReactModuleName.js
+++ b/src/utils/isReactModuleName.js
@@ -10,7 +10,7 @@
  *
  */
 
-var reactModules = ['react', 'react/addons', 'react-native'];
+var reactModules = ['react', 'react/addons', 'react-native', 'proptypes'];
 
 /**
  * Takes a module name (string) and returns true if it refers to a root react


### PR DESCRIPTION
This PR adds @developit's [proptypes module](https://github.com/developit/proptypes) to the list of recognised React modules, for better support of engines other than Facebook's React. In this case, I'm using it with [Preact](https://preactjs.com/).

Having looked at #96, I don't know if adding another hardcoded value to the list of modules is the way you want to go. If you prefer a more flexible solution of being able to supply the names of the modules to validate against, I can also look into that if you give me some pointers.

Thanks!