### PR TITLE
Remove coverage folder from NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 /src
 /flow
 /tests
+/coverage
 preprocessor.js
 __tests__
 __mocks__


### PR DESCRIPTION
I found a coverage folder in this module which was 1mb, so I thought I'd remove it.

![screenshot from 2017-03-22 10 44 56](https://cloud.githubusercontent.com/assets/1611595/24194095/99eaba78-0eec-11e7-9aec-7f1f7ed4c640.png)

:heart: 
