### PR TITLE
Add support for new prop-types package

### DIFF
--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -128,3 +128,37 @@ Object {
   },
 }
 `;
+
+exports[`main fixtures processes component "component_6.js" without errors 1`] = `
+Object {
+  "description": "",
+  "methods": Array [],
+  "props": Object {
+    "children": Object {
+      "description": "",
+      "required": true,
+      "type": Object {
+        "name": "string",
+      },
+    },
+    "onClick": Object {
+      "description": "",
+      "required": false,
+      "type": Object {
+        "name": "func",
+      },
+    },
+    "style": Object {
+      "defaultValue": Object {
+        "computed": false,
+        "value": "{}",
+      },
+      "description": "",
+      "required": false,
+      "type": Object {
+        "name": "object",
+      },
+    },
+  },
+}
+`;

--- a/src/__tests__/fixtures/component_6.js
+++ b/src/__tests__/fixtures/component_6.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Button = ({ children, onClick, style = {} }) => (
+  <button
+    style={{ }}
+    onClick={onClick}
+  >
+    {children}
+  </button>
+);
+
+Button.propTypes = {
+  children: PropTypes.string.isRequired,
+  onClick: PropTypes.func,
+  style: PropTypes.object,
+};
+
+export default Button;

--- a/src/utils/isReactModuleName.js
+++ b/src/utils/isReactModuleName.js
@@ -10,7 +10,7 @@
  *
  */
 
-var reactModules = ['react', 'react/addons', 'react-native', 'proptypes'];
+var reactModules = ['react', 'react/addons', 'react-native', 'proptypes', 'prop-types'];
 
 /**
  * Takes a module name (string) and returns true if it refers to a root react


### PR DESCRIPTION
This resolves #171. 

[React 15.5.0](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html) introduced a new `prop-types` package and deprecated `React.PropTypes`. Currently `react-docgen` doesn't recognize the [`prop-types`](https://www.npmjs.com/package/prop-types) package as a React module, so it sets the `type` to `custom` for all PropTypes.