### PR TITLE
test(matcher): Add a readable message with diff to the AST matcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "eslint": "^4.3.0",
     "flow-bin": "^0.50.0",
     "jest": "^20.0.4",
+    "jest-diff": "^20.0.3",
+    "jest-matcher-utils": "^20.0.3",
     "rimraf": "^2.3.2",
     "temp": "^0.8.1"
   },


### PR DESCRIPTION
This improves the output of the matcher because I wasn't able to see what the diff in the AST actually was :)

This also makes use of js features that node 4+ supports.

<img width="1167" alt="bildschirmfoto 2017-08-24 um 23 07 44" src="https://user-images.githubusercontent.com/231804/29688959-d2a0b142-8921-11e7-9d89-4f11f3ff324b.png">
