### PR TITLE
chore(publish): change to npm whitelist to exclude unnecessary files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-/src
-/flow
-/tests
-/coverage
-preprocessor.js
-__tests__
-__mocks__

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   "bin": {
     "react-docgen": "bin/react-docgen.js"
   },
+  "files":[
+    "bin",
+    "dist"
+  ],
   "main": "dist/main.js",
   "scripts": {
     "check": "npm run lint && npm run flow && npm test",


### PR DESCRIPTION
This will now only include `bin/` and `dist/` in the package and leave out all other files (besides LICENSE and README.md) 