### PR TITLE
Add support for function paramets without names

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ type Props = {
   literalsAndUnion: 'string' | 'otherstring' | number,
   arr: Array<any>,
   func?: (value: string) => void,
+  noParameterName?: string => void,
   obj?: { subvalue: ?boolean },
 };
 
@@ -282,6 +283,20 @@ we are getting this output:
         "signature":{
           "arguments":[
             { "name":"value", "type":{ "name":"string" } }
+          ],
+          "return":{ "name":"void" }
+        }
+      },
+      "required":false
+    },
+    "noParameterName":{
+      "flowType":{
+        "name":"signature",
+        "type":"function",
+        "raw":"string => void",
+        "signature":{
+          "arguments":[
+            { "name":"", "type":{ "name":"string" } }
           ],
           "return":{ "name":"void" }
         }

--- a/src/utils/__tests__/getFlowType-test.js
+++ b/src/utils/__tests__/getFlowType-test.js
@@ -139,6 +139,27 @@ describe('getFlowType', () => {
     }, raw: '(p1: number, p2: ?string) => boolean'});
   });
 
+
+  it('detects function signature types without parameter names', () => {
+    var typePath = expression('x: (number, ?string) => boolean').get('typeAnnotation').get('typeAnnotation');
+    expect(getFlowType(typePath)).toEqual({name: 'signature', type: 'function', signature: {
+      arguments: [
+        { name: '', type: { name: 'number' }},
+        { name: '', type: { name: 'string', nullable: true }},
+      ],
+      return: { name: 'boolean' },
+    }, raw: '(number, ?string) => boolean'});
+  });
+
+  it('detects function signature type with single parmeter without name', () => {
+    var typePath = expression('x: string => boolean').get('typeAnnotation').get('typeAnnotation');
+    expect(getFlowType(typePath)).toEqual({name: 'signature', type: 'function', signature: {
+      arguments: [
+        { name: '', type: { name: 'string' }},
+      ],
+      return: { name: 'boolean' },
+    }, raw: 'string => boolean'});
+  });
   it('detects callable signature type', () => {
     var typePath = expression('x: { (str: string): string, token: string }').get('typeAnnotation').get('typeAnnotation');
     expect(getFlowType(typePath)).toEqual({name: 'signature', type: 'object', signature: {

--- a/src/utils/getFlowType.js
+++ b/src/utils/getFlowType.js
@@ -148,7 +148,7 @@ function handleFunctionTypeAnnotation(path: NodePath) {
     if (!typeAnnotation) return null;
 
     type.signature.arguments.push({
-      name: getPropertyName(param.get('name')),
+      name: param.node.name ? param.node.name.name : '',
       type: getFlowType(typeAnnotation),
     });
   });


### PR DESCRIPTION
Add support for flow functions with parameters that doesn't have a name.
Eg. `value: string => void` and `value: (string, number) => void`

This kind of functions ins't currently supported by `react-docgen`, and it's unable to parse the file.

Source: [flow](https://flow.org/en/docs/types/functions/#toc-function-types)