### PR TITLE
Update babylon to latest beta and fix detection of comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "async": "^2.1.4",
     "babel-runtime": "^6.9.2",
-    "babylon": "v7.0.0-beta.20",
+    "babylon": "7.0.0-beta.29",
     "commander": "^2.9.0",
     "doctrine": "^2.0.0",
     "node-dir": "^0.1.10",

--- a/src/utils/docblock.js
+++ b/src/utils/docblock.js
@@ -29,9 +29,14 @@ let DOCBLOCK_HEADER = /^\*\s/;
  * Given a path, this function returns the closest preceding docblock if it
  * exists.
  */
-export function getDocblock(path: NodePath): ?string {
+export function getDocblock(path: NodePath, trailing: boolean = false): ?string {
   var comments = [];
-  if (path.node.leadingComments) {
+  if (trailing && path.node.trailingComments) {
+    comments = path.node.trailingComments.filter(
+      comment => comment.type === 'CommentBlock' &&
+        DOCBLOCK_HEADER.test(comment.value)
+    );
+  } else if (path.node.leadingComments) {
     comments = path.node.leadingComments.filter(
       comment => comment.type === 'CommentBlock' &&
         DOCBLOCK_HEADER.test(comment.value)

--- a/yarn.lock
+++ b/yarn.lock
@@ -748,13 +748,13 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
+babylon@7.0.0-beta.29:
+  version "7.0.0-beta.29"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.29.tgz#6a3e0e6287390385a36f5511e7f94db8618574ae"
+
 babylon@^6.17.0, babylon@^6.17.2, babylon@^6.17.4:
   version "6.17.4"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
-
-babylon@v7.0.0-beta.20:
-  version "7.0.0-beta.20"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.20.tgz#7dbc70cc88de13334066fe5200e0efaa30c0490e"
 
 balanced-match@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The comment attachment changed in babylon a little bit, because decorators are not considered part of the class declaration.

This fixes react-docgen to make all the usecases still work.