### PR TITLE
 Resolve flow $Keys<> to union type

### DIFF
--- a/src/utils/__tests__/getFlowType-test.js
+++ b/src/utils/__tests__/getFlowType-test.js
@@ -263,4 +263,19 @@ describe('getFlowType', () => {
       { name: 'literal', value: "'banana'" },
     ], raw: '$Keys<typeof CONTENTS>'});
   });
+
+  it('resolves $Keys without typeof to union', () => {
+    var typePath = statement(`
+      var x: $Keys<CONTENTS> = 2;
+      const CONTENTS = {
+        'apple': '🍎',
+        'banana': '🍌',
+      };
+    `).get('declarations', 0).get('id').get('typeAnnotation').get('typeAnnotation');
+
+    expect(getFlowType(typePath)).toEqual({name: 'union', elements: [
+      { name: 'literal', value: "'apple'" },
+      { name: 'literal', value: "'banana'" },
+    ], raw: '$Keys<CONTENTS>'});
+  });
 });

--- a/src/utils/__tests__/getFlowType-test.js
+++ b/src/utils/__tests__/getFlowType-test.js
@@ -248,4 +248,19 @@ describe('getFlowType', () => {
       it(type, () => test(type, types[type]));
     });
   });
+
+  it('resolves $Keys to union', () => {
+    var typePath = statement(`
+      var x: $Keys<typeof CONTENTS> = 2;
+      const CONTENTS = {
+        'apple': '🍎',
+        'banana': '🍌',
+      };
+    `).get('declarations', 0).get('id').get('typeAnnotation').get('typeAnnotation');
+
+    expect(getFlowType(typePath)).toEqual({name: 'union', elements: [
+      { name: 'literal', value: "'apple'" },
+      { name: 'literal', value: "'banana'" },
+    ], raw: '$Keys<typeof CONTENTS>'});
+  });
 });

--- a/src/utils/resolveObjectKeysToArray.js
+++ b/src/utils/resolveObjectKeysToArray.js
@@ -32,7 +32,7 @@ function isObjectKeysCall(node: ASTNode): bool {
     node.callee.property.name === 'keys';
 }
 
-function resolveObjectExpressionToNameArray(objectExpression: NodePath): ?Array<string> {
+export function resolveObjectExpressionToNameArray(objectExpression: NodePath, raw: boolean = false): ?Array<string> {
   if (
     types.ObjectExpression.check(objectExpression.value) &&
     objectExpression.value.properties.every(
@@ -53,7 +53,7 @@ function resolveObjectExpressionToNameArray(objectExpression: NodePath): ?Array<
 
       if (types.Property.check(prop)) {
         // Key is either Identifier or Literal
-        const name = prop.key.name || prop.key.value;
+        const name = prop.key.name || (raw ? prop.key.raw : prop.key.value);
 
         values.push(name);
       } else if (types.SpreadProperty.check(prop)) {


### PR DESCRIPTION
`resolveObjectExpressionToNameArray` could be extracted into a separate handler, but I tried to keep the diff for now as minimal as possible

Fixes #154