### PR TITLE
Added post-processing step for documentation objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "scripts": {
     "build": "rimraf dist/ && babel src/ --out-dir dist/ --ignore __tests__,__mocks__",
     "lint": "eslint src/ bin/",
-    "prepublish": "yarn run build",
-    "preversion": "yarn run lint",
+    "prepublish": "yarn build",
+    "preversion": "yarn lint",
     "test": "jest",
     "test:ci": "yarn lint && yarn flow && yarn test --runInBand",
     "watch": "yarn build --watch"

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -38,6 +38,7 @@ Object {
         "computed": false,
         "value": "\\"primary\\"",
       },
+      "required": false,
     },
   },
 }
@@ -256,6 +257,34 @@ Object {
       "type": Object {
         "name": "string",
       },
+    },
+  },
+}
+`;
+
+exports[`main fixtures processes component "component_11.js" without errors 1`] = `
+Object {
+  "description": "",
+  "displayName": "Foo",
+  "methods": Array [],
+  "props": Object {
+    "prop1": Object {
+      "description": "",
+      "flowType": Object {
+        "name": "string",
+      },
+      "required": true,
+    },
+    "prop2": Object {
+      "defaultValue": Object {
+        "computed": false,
+        "value": "'bar'",
+      },
+      "description": "",
+      "flowType": Object {
+        "name": "string",
+      },
+      "required": false,
     },
   },
 }

--- a/src/__tests__/fixtures/component_11.js
+++ b/src/__tests__/fixtures/component_11.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+ /**
+  * Test for documentation of React components with Flow annotations for props.
+  */
+
+import React from 'react';
+
+type Props = {
+    prop1: string,
+    prop2: string,
+};
+
+class Foo extends React.Component<Props> {
+    render() {
+        return (
+            <div>
+                {this.props.prop1}
+                I am Foo!
+                {this.props.prop2}
+            </div>
+        );
+    }
+}
+
+Foo.defaultProps = {
+    prop2: 'bar',
+};
+
+export default Foo;

--- a/src/parse.js
+++ b/src/parse.js
@@ -11,6 +11,7 @@
  */
 
 import Documentation from './Documentation';
+import postProcessDocumentation from './utils/postProcessDocumentation';
 
 import babylon from './babylon';
 import recast from 'recast';
@@ -21,7 +22,7 @@ function executeHandlers(handlers, componentDefinitions) {
   return componentDefinitions.map(componentDefinition => {
     var documentation = new Documentation();
     handlers.forEach(handler => handler(documentation, componentDefinition));
-    return documentation.toObject();
+    return postProcessDocumentation(documentation.toObject());
   });
 }
 

--- a/src/utils/postProcessDocumentation.js
+++ b/src/utils/postProcessDocumentation.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+function postProcessProps(props) {
+  // props with default values should not be required
+  Object.keys(props).forEach(prop => {
+    const propInfo = props[prop];
+
+    if (propInfo.defaultValue) {
+      propInfo.required = false;
+    }
+  });
+}
+
+export default function (documentation) {
+  const props = documentation.props;
+
+  if (props) {
+    postProcessProps(props);
+  }
+
+  return documentation;
+}


### PR DESCRIPTION
Definitely a WIP, but thought I'd get a PR going to have something to discuss on. This branch adds a post-processing step for documentation objects. Currently, this post-processing step only does what's needed to "fix" #221, but I can imagine we could use it for validation of documentation objects as well? I haven't added any tests yet. Let me know what you think!