### PR TITLE
Post process flow default props

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,31 +32,31 @@
   "author": "Felix Kling",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "async": "^2.1.4",
-    "babel-runtime": "^6.9.2",
+    "async": "^2.6.0",
+    "babel-runtime": "^6.26.0",
     "babylon": "7.0.0-beta.31",
-    "commander": "^2.9.0",
+    "commander": "^2.11.0",
     "doctrine": "^2.0.0",
-    "node-dir": "^0.1.10",
-    "recast": "^0.12.6"
+    "node-dir": "^0.1.17",
+    "recast": "^0.12.9"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
-    "babel-eslint": "^8.0.1",
+    "babel-eslint": "^8.0.2",
     "babel-jest": "^21.2.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-flow": "^6.23.0",
-    "cross-spawn": "^5.0.0",
-    "eslint": "^4.3.0",
+    "cross-spawn": "^5.1.0",
+    "eslint": "^4.11.0",
     "flow-bin": "^0.59.0",
     "jest": "^21.2.1",
     "jest-diff": "^21.2.1",
     "jest-matcher-utils": "^21.2.1",
-    "rimraf": "^2.3.2",
-    "temp": "^0.8.1"
+    "rimraf": "^2.6.2",
+    "temp": "^0.8.3"
   },
   "jest": {
     "setupTestFrameworkScriptFile": "<rootDir>/tests/setupTestFramework.js",

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -38,6 +38,7 @@ Object {
         "computed": false,
         "value": "\\"primary\\"",
       },
+      "required": false,
     },
   },
 }
@@ -256,6 +257,67 @@ Object {
       "type": Object {
         "name": "string",
       },
+    },
+  },
+}
+`;
+
+exports[`main fixtures processes component "component_11.js" without errors 1`] = `
+Object {
+  "description": "",
+  "displayName": "Paper",
+  "methods": Array [],
+  "props": Object {
+    "children": Object {
+      "description": "@ignore",
+      "flowType": Object {
+        "name": "Node",
+      },
+      "required": false,
+    },
+    "classes": Object {
+      "description": "Useful to extend the style applied to components.",
+      "flowType": Object {
+        "name": "Object",
+      },
+      "required": false,
+    },
+    "component": Object {
+      "defaultValue": Object {
+        "computed": false,
+        "value": "'div': ElementType",
+      },
+      "description": "The component used for the root node.
+This currently has to be flow cast in defaultProps as of flow 0.59.0",
+      "flowType": Object {
+        "name": "ElementType",
+      },
+      "required": false,
+    },
+    "elevation": Object {
+      "defaultValue": Object {
+        "computed": false,
+        "value": "2",
+      },
+      "description": "Shadow depth, corresponds to \`dp\` in the spec.
+It's accepting values between 0 and 24 inclusive.",
+      "flowType": Object {
+        "name": "number",
+      },
+      "required": false,
+    },
+    "transition": Object {
+      "description": "Transition component.",
+      "flowType": Object {
+        "elements": Array [
+          Object {
+            "name": "unknown",
+          },
+        ],
+        "name": "ComponentType",
+        "raw": "ComponentType<*>",
+      },
+      "required": true,
     },
   },
 }

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -285,7 +285,7 @@ Object {
     "component": Object {
       "defaultValue": Object {
         "computed": false,
-        "value": "'div': ElementType",
+        "value": "'div'",
       },
       "description": "The component used for the root node.
 This currently has to be flow cast in defaultProps as of flow 0.59.0",

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -272,8 +272,8 @@ Object {
       "defaultValue": Object {
         "computed": false,
         "value": "{
-  vertical: 'top',
-  horizontal: 'left',
+ vertical: 'top',
+ horizontal: 'left'
 }",
       },
       "description": "This is the point on the anchor where the popover's
@@ -394,6 +394,53 @@ It's accepting values between 0 and 24 inclusive.",
 object.",
       "flowType": Object {
         "name": "Node",
+      },
+      "required": false,
+    },
+    "timeout": Object {
+      "defaultValue": Object {
+        "computed": false,
+        "value": "duration.standard",
+      },
+      "description": "The duration for the transition, in milliseconds.
+You may specify a single timeout for all transitions, or individually with an object.
+
+Set to 'auto' to automatically calculate transition time based on height.",
+      "flowType": Object {
+        "elements": Array [
+          Object {
+            "name": "number",
+          },
+          Object {
+            "name": "signature",
+            "raw": "{ enter?: number, exit?: number }",
+            "signature": Object {
+              "properties": Array [
+                Object {
+                  "key": "enter",
+                  "value": Object {
+                    "name": "number",
+                    "required": false,
+                  },
+                },
+                Object {
+                  "key": "exit",
+                  "value": Object {
+                    "name": "number",
+                    "required": false,
+                  },
+                },
+              ],
+            },
+            "type": "object",
+          },
+          Object {
+            "name": "literal",
+            "value": "'auto'",
+          },
+        ],
+        "name": "union",
+        "raw": "number | { enter?: number, exit?: number } | 'auto'",
       },
       "required": false,
     },

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -268,6 +268,85 @@ Object {
   "displayName": "Paper",
   "methods": Array [],
   "props": Object {
+    "anchorOrigin": Object {
+      "defaultValue": Object {
+        "computed": false,
+        "value": "{
+  vertical: 'top',
+  horizontal: 'left',
+}",
+      },
+      "description": "This is the point on the anchor where the popover's
+\`anchorEl\` will attach to. This is not used when the
+anchorReference is 'anchorPosition'.
+
+Options:
+vertical: [top, center, bottom];
+horizontal: [left, center, right].",
+      "flowType": Object {
+        "name": "signature",
+        "raw": "{
+  horizontal: 'left' | 'center' | 'right' | number,
+  vertical: 'top' | 'center' | 'bottom' | number,
+}",
+        "signature": Object {
+          "properties": Array [
+            Object {
+              "key": "horizontal",
+              "value": Object {
+                "elements": Array [
+                  Object {
+                    "name": "literal",
+                    "value": "'left'",
+                  },
+                  Object {
+                    "name": "literal",
+                    "value": "'center'",
+                  },
+                  Object {
+                    "name": "literal",
+                    "value": "'right'",
+                  },
+                  Object {
+                    "name": "number",
+                  },
+                ],
+                "name": "union",
+                "raw": "'left' | 'center' | 'right' | number",
+                "required": true,
+              },
+            },
+            Object {
+              "key": "vertical",
+              "value": Object {
+                "elements": Array [
+                  Object {
+                    "name": "literal",
+                    "value": "'top'",
+                  },
+                  Object {
+                    "name": "literal",
+                    "value": "'center'",
+                  },
+                  Object {
+                    "name": "literal",
+                    "value": "'bottom'",
+                  },
+                  Object {
+                    "name": "number",
+                  },
+                ],
+                "name": "union",
+                "raw": "'top' | 'center' | 'bottom' | number",
+                "required": true,
+              },
+            },
+          ],
+        },
+        "type": "object",
+      },
+      "required": false,
+    },
     "children": Object {
       "description": "@ignore",
       "flowType": Object {

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -306,6 +306,18 @@ It's accepting values between 0 and 24 inclusive.",
       },
       "required": false,
     },
+    "labelRowsPerPage": Object {
+      "defaultValue": Object {
+        "computed": false,
+        "value": "'Rows per page:'",
+      },
+      "description": "Useful to customize the rows per page label. Invoked with a \`{ from, to, count, page }\`
+object.",
+      "flowType": Object {
+        "name": "Node",
+      },
+      "required": false,
+    },
     "transition": Object {
       "description": "Transition component.",
       "flowType": Object {

--- a/src/__tests__/fixtures/component_11.js
+++ b/src/__tests__/fixtures/component_11.js
@@ -35,6 +35,11 @@ export type Props = {
    */
   elevation: number,
   /**
+   * Useful to customize the rows per page label. Invoked with a `{ from, to, count, page }`
+   * object.
+   */
+  labelRowsPerPage: Node,
+  /**
    * Transition component.
    */
   transition: ComponentType<*>,
@@ -42,6 +47,7 @@ export type Props = {
 
 class Paper extends React.Component<ProvidedProps & Props> {
   static defaultProps = {
+    labelRowsPerPage: ('Rows per page:': Node),
     component: ('div': ElementType),
     elevation: 2,
   };

--- a/src/__tests__/fixtures/component_11.js
+++ b/src/__tests__/fixtures/component_11.js
@@ -16,6 +16,12 @@ export type Origin = {
   vertical: 'top' | 'center' | 'bottom' | number,
 };
 
+export const duration = {
+  standard: 300,
+};
+
+export type TransitionDuration = number | { enter?: number, exit?: number } | 'auto';
+
 export type Props = {
   /**
    * Other base element props.
@@ -58,18 +64,27 @@ export type Props = {
    * Transition component.
    */
   transition: ComponentType<*>,
+  /**
+   * The duration for the transition, in milliseconds.
+   * You may specify a single timeout for all transitions, or individually with an object.
+   *
+   * Set to 'auto' to automatically calculate transition time based on height.
+   */
+  timeout: TransitionDuration,
 };
 
 class Paper extends React.Component<ProvidedProps & Props> {
   static defaultProps = {
-    anchorOrigin: {
+    anchorOrigin: ({
       vertical: 'top',
       horizontal: 'left',
-    },
+    }: Origin),
     labelRowsPerPage: ('Rows per page:': Node),
     component: ('div': ElementType),
     component: 'div',
     elevation: 2,
+    timeout: (duration.standard: TransitionDuration),
+    //timeout: duration.standard,
   };
 
   render() {

--- a/src/__tests__/fixtures/component_11.js
+++ b/src/__tests__/fixtures/component_11.js
@@ -84,7 +84,6 @@ class Paper extends React.Component<ProvidedProps & Props> {
     component: 'div',
     elevation: 2,
     timeout: (duration.standard: TransitionDuration),
-    //timeout: duration.standard,
   };
 
   render() {

--- a/src/__tests__/fixtures/component_11.js
+++ b/src/__tests__/fixtures/component_11.js
@@ -1,0 +1,61 @@
+// @flow
+
+/**
+ * Test for documentation of flow class
+ */
+
+import React from 'react';
+import type { ComponentType, ElementType, Node } from 'react';
+
+type ProvidedProps = {
+  classes: Object,
+};
+
+export type Props = {
+  /**
+   * Other base element props.
+   */
+  [otherProp: string]: any,
+  /**
+   * Useful to extend the style applied to components.
+   */
+  classes?: Object,
+  /**
+   * @ignore
+   */
+  children?: Node,
+  /**
+   * The component used for the root node.
+   * This currently has to be flow cast in defaultProps as of flow 0.59.0
+   */
+  component: ElementType,
+  /**
+   * Shadow depth, corresponds to `dp` in the spec.
+   * It's accepting values between 0 and 24 inclusive.
+   */
+  elevation: number,
+  /**
+   * Transition component.
+   */
+  transition: ComponentType<*>,
+};
+
+class Paper extends React.Component<ProvidedProps & Props> {
+  static defaultProps = {
+    component: ('div': ElementType),
+    elevation: 2,
+  };
+
+  render() {
+    const {
+      classes,
+      component: ComponentProp,
+      transition,
+      ...other
+    } = this.props;
+
+    return <ComponentProp className={classes.root} transition={transition} {...other} />;
+  }
+}
+
+export default Paper;

--- a/src/__tests__/fixtures/component_11.js
+++ b/src/__tests__/fixtures/component_11.js
@@ -11,11 +11,26 @@ type ProvidedProps = {
   classes: Object,
 };
 
+export type Origin = {
+  horizontal: 'left' | 'center' | 'right' | number,
+  vertical: 'top' | 'center' | 'bottom' | number,
+};
+
 export type Props = {
   /**
    * Other base element props.
    */
   [otherProp: string]: any,
+  /**
+   * This is the point on the anchor where the popover's
+   * `anchorEl` will attach to. This is not used when the
+   * anchorReference is 'anchorPosition'.
+   *
+   * Options:
+   * vertical: [top, center, bottom];
+   * horizontal: [left, center, right].
+   */
+  anchorOrigin?: Origin,
   /**
    * Useful to extend the style applied to components.
    */
@@ -47,8 +62,13 @@ export type Props = {
 
 class Paper extends React.Component<ProvidedProps & Props> {
   static defaultProps = {
+    anchorOrigin: {
+      vertical: 'top',
+      horizontal: 'left',
+    },
     labelRowsPerPage: ('Rows per page:': Node),
     component: ('div': ElementType),
+    component: 'div',
     elevation: 2,
   };
 

--- a/src/handlers/defaultPropsHandler.js
+++ b/src/handlers/defaultPropsHandler.js
@@ -28,12 +28,12 @@ function getDefaultValue(path: NodePath) {
   if (types.Literal.check(node)) {
     defaultValue = node.raw;
   } else {
-    if (types.AssignmentPattern.check(node)) {
+    if (types.AssignmentPattern.check(path.node)) {
       path = resolveToValue(path.get('right'));
     } else {
       path = resolveToValue(path);
     }
-    if (types.ImportDeclaration.check(node)) {
+    if (types.ImportDeclaration.check(path.node)) {
       defaultValue = node.name;
     } else {
       node = path.node;

--- a/src/handlers/defaultPropsHandler.js
+++ b/src/handlers/defaultPropsHandler.js
@@ -24,6 +24,10 @@ var {types: {namedTypes: types}} = recast;
 
 function getDefaultValue(path: NodePath) {
   var node = path.node;
+  if(types.TypeCastExpression.check(node)) {
+    node = node.expression;
+  }
+
   var defaultValue;
   if (types.Literal.check(node)) {
     defaultValue = node.raw;

--- a/src/handlers/defaultPropsHandler.js
+++ b/src/handlers/defaultPropsHandler.js
@@ -24,20 +24,16 @@ var {types: {namedTypes: types}} = recast;
 
 function getDefaultValue(path: NodePath) {
   var node = path.node;
-  if(types.TypeCastExpression.check(node)) {
-    node = node.expression;
-  }
-
   var defaultValue;
   if (types.Literal.check(node)) {
     defaultValue = node.raw;
   } else {
-    if (types.AssignmentPattern.check(path.node)) {
+    if (types.AssignmentPattern.check(node)) {
       path = resolveToValue(path.get('right'));
     } else {
       path = resolveToValue(path);
     }
-    if (types.ImportDeclaration.check(path.node)) {
+    if (types.ImportDeclaration.check(node)) {
       defaultValue = node.name;
     } else {
       node = path.node;

--- a/src/parse.js
+++ b/src/parse.js
@@ -14,6 +14,7 @@ import Documentation from './Documentation';
 
 import babylon from './babylon';
 import recast from 'recast';
+import postProcessDocumentation from './utils/postProcessDocumentation';
 
 var ERROR_MISSING_DEFINITION = 'No suitable component definition found.';
 
@@ -21,7 +22,7 @@ function executeHandlers(handlers, componentDefinitions) {
   return componentDefinitions.map(componentDefinition => {
     var documentation = new Documentation();
     handlers.forEach(handler => handler(documentation, componentDefinition));
-    return documentation.toObject();
+    return postProcessDocumentation(documentation.toObject());
   });
 }
 

--- a/src/utils/postProcessDocumentation.js
+++ b/src/utils/postProcessDocumentation.js
@@ -9,8 +9,6 @@
  * @flow
  */
 
-import Documentation from '../Documentation';
-
 function postProcessProps(props) {
   // props with default values should not be required
   Object.keys(props).forEach(prop => {
@@ -18,6 +16,11 @@ function postProcessProps(props) {
 
     if (propInfo.defaultValue) {
       propInfo.required = false;
+
+      // check and remove any flow type cast
+      propInfo.defaultValue.value = propInfo.defaultValue.value.includes(':') ?
+        propInfo.defaultValue.value.split(':')[0] :
+        propInfo.defaultValue.value
     }
   });
 }

--- a/src/utils/postProcessDocumentation.js
+++ b/src/utils/postProcessDocumentation.js
@@ -16,11 +16,6 @@ function postProcessProps(props) {
 
     if (propInfo.defaultValue) {
       propInfo.required = false;
-
-      // Check and remove any flow type cast.  Use last `:` in case description has `:` in it.
-      propInfo.defaultValue.value = propInfo.defaultValue.value.includes(':') ?
-        propInfo.defaultValue.value.slice(0, propInfo.defaultValue.value.lastIndexOf(':')) :
-        propInfo.defaultValue.value
     }
   });
 }

--- a/src/utils/postProcessDocumentation.js
+++ b/src/utils/postProcessDocumentation.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+import Documentation from '../Documentation';
+
+function postProcessProps(props) {
+  // props with default values should not be required
+  Object.keys(props).forEach(prop => {
+    const propInfo = props[prop];
+
+    if (propInfo.defaultValue) {
+      propInfo.required = false;
+    }
+  });
+}
+
+export default function (documentation: any) {
+  const props = documentation.props;
+  if (props) {
+    postProcessProps(props);
+  }
+
+  return documentation;
+}

--- a/src/utils/postProcessDocumentation.js
+++ b/src/utils/postProcessDocumentation.js
@@ -17,9 +17,9 @@ function postProcessProps(props) {
     if (propInfo.defaultValue) {
       propInfo.required = false;
 
-      // check and remove any flow type cast
+      // Check and remove any flow type cast.  Use last `:` in case description has `:` in it.
       propInfo.defaultValue.value = propInfo.defaultValue.value.includes(':') ?
-        propInfo.defaultValue.value.split(':')[0] :
+        propInfo.defaultValue.value.slice(0, propInfo.defaultValue.value.lastIndexOf(':')) :
         propInfo.defaultValue.value
     }
   });

--- a/src/utils/printValue.js
+++ b/src/utils/printValue.js
@@ -12,6 +12,8 @@
 
 import recast from 'recast';
 
+var {types: {namedTypes: types}} = recast;
+
 /**
  * Prints the given path without leading or trailing comments.
  */
@@ -19,5 +21,10 @@ export default function printValue(path: NodePath): string {
   if (path.node.comments) {
     path.node.comments.length = 0;
   }
-  return recast.print(path).code;
+
+  if(types.TypeCastExpression.check(path.node)) {
+    return recast.print(path.node.expression).code
+  } else {
+    return recast.print(path).code;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,7 +83,7 @@ acorn@^4.0.4:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-acorn@^5.1.1:
+acorn@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
 
@@ -98,7 +98,7 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.0, ajv@^5.2.0, ajv@^5.2.3:
+ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.3.0.tgz#4414ff74a50879c208ee5fdc826e32c303549eda"
   dependencies:
@@ -215,9 +215,9 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
-ast-types@0.9.14:
-  version "0.9.14"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.14.tgz#d34ba5dffb9d15a44351fd2a9d82e4ab2838b5ba"
+ast-types@0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.10.1.tgz#f52fca9715579a14f841d67d7f8d25432ab6a3dd"
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -231,7 +231,7 @@ async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.1.4:
+async@^2.1.4, async@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:
@@ -306,7 +306,7 @@ babel-core@^6.0.0, babel-core@^6.26.0:
     slash "^1.0.0"
     source-map "^0.5.6"
 
-babel-eslint@^8.0.1:
+babel-eslint@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.0.2.tgz#e44fb9a037d749486071d52d65312f5c20aa7530"
   dependencies:
@@ -765,7 +765,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.9.2:
+babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -1017,7 +1017,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.11.0, commander@^2.9.0:
+commander@^2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
@@ -1053,7 +1053,7 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cross-spawn@^5.0.0, cross-spawn@^5.0.1, cross-spawn@^5.1.0:
+cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -1204,11 +1204,11 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^4.3.0:
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.10.0.tgz#f25d0d7955c81968c2309aa5c9a229e045176bb7"
+eslint@^4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.11.0.tgz#39a8c82bc0a3783adf5a39fa27fdd9d36fac9a34"
   dependencies:
-    ajv "^5.2.0"
+    ajv "^5.3.0"
     babel-code-frame "^6.22.0"
     chalk "^2.1.0"
     concat-stream "^1.6.0"
@@ -1216,7 +1216,7 @@ eslint@^4.3.0:
     debug "^3.0.1"
     doctrine "^2.0.0"
     eslint-scope "^3.7.1"
-    espree "^3.5.1"
+    espree "^3.5.2"
     esquery "^1.0.0"
     estraverse "^4.2.0"
     esutils "^2.0.2"
@@ -1229,7 +1229,7 @@ eslint@^4.3.0:
     inquirer "^3.0.6"
     is-resolvable "^1.0.0"
     js-yaml "^3.9.1"
-    json-stable-stringify "^1.0.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
     lodash "^4.17.4"
     minimatch "^3.0.2"
@@ -1246,11 +1246,11 @@ eslint@^4.3.0:
     table "^4.0.1"
     text-table "~0.2.0"
 
-espree@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.1.tgz#0c988b8ab46db53100a1954ae4ba995ddd27d87e"
+espree@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.2.tgz#756ada8b979e9dcfcdb30aad8d1a9304a905e1ca"
   dependencies:
-    acorn "^5.1.1"
+    acorn "^5.2.1"
     acorn-jsx "^3.0.0"
 
 esprima@^3.1.3:
@@ -2221,6 +2221,10 @@ json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
 
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+
 json-stable-stringify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
@@ -2416,7 +2420,7 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-node-dir@^0.1.10:
+node-dir@^0.1.17:
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"
   dependencies:
@@ -2793,11 +2797,11 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
-recast@^0.12.6:
-  version "0.12.8"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.12.8.tgz#bb5dc9501dfa0cd075686e1daf9d67797cc5499f"
+recast@^0.12.9:
+  version "0.12.9"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.12.9.tgz#e8e52bdb9691af462ccbd7c15d5a5113647a15f1"
   dependencies:
-    ast-types "0.9.14"
+    ast-types "0.10.1"
     core-js "^2.4.1"
     esprima "~4.0.0"
     private "~0.1.5"
@@ -2955,7 +2959,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.5.1, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -3221,7 +3225,7 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
-temp@^0.8.1:
+temp@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
   dependencies:


### PR DESCRIPTION
Fixes #221 

Based on the work by @adityavohra7 in #227 (on `master`), I have applied a similar change to `v3-dev` with post processing of defaultProps.  Props are not required when they are specified in `defaultProps`.   

Further, I added `component_11.js` as a diverse test case taken from `material-ui`.  It Is an all flow test that exercises required, optional, and parameterized types.

Use case: https://github.com/callemall/material-ui/issues/9222