### PR TITLE
[RFC] Speed up react-docgen by 25-40%

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -50,7 +50,11 @@ export default function parse(
   resolver: Resolver,
   handlers: Array<Handler>
 ): Array<Object>|Object {
-  var ast = recast.parse(src, {esprima: babylon});
+  let ast = babylon.parse(src, {
+   sourceType: 'module'
+  });
+  ast._docgenOriginalFileSource = src;
+  ast = recast.types.builders.file(ast, null);
   var componentDefinitions = resolver(ast.program, recast);
 
   if (Array.isArray(componentDefinitions)) {

--- a/src/utils/printValue.js
+++ b/src/utils/printValue.js
@@ -16,8 +16,28 @@ import recast from 'recast';
  * Prints the given path without leading or trailing comments.
  */
 export default function printValue(path: NodePath): string {
-  if (path.node.comments) {
-    path.node.comments.length = 0;
+  let p = path;
+  while (p.parentPath) {
+    p = p.parentPath;
   }
-  return recast.print(path).code;
+  const fileSource = p.value.root._docgenOriginalFileSource;
+
+  let indent = 0;
+  p = path;
+  while (p.parentPath) {
+    if (!/\S/.test(fileSource.slice(
+      p.node.start - p.node.loc.start.column,
+      p.node.start
+    ))) {
+      indent = p.node.loc.start.column;
+      break;
+    }
+    p = p.parentPath;
+  }
+
+  let snippet = fileSource.slice(path.node.start, path.node.end);
+  if (indent > 0) {
+    snippet = snippet.replace(new RegExp("(\\n)\\s{1," + indent + "}", "g"), "$1");
+  }
+  return snippet;
 }


### PR DESCRIPTION
I did some profiling and noticed that recast has a significant amount of overhead due to the fact that it copies every tree it parses and has complicated printing logic. I wasn't sure if react-docgen uses any mutative recast features so I tried to remove it.

The good news: this is about 25-40% faster in my testing (40% faster when run on 20 files, 25% faster when run on 700 components from FB internal repos -- probably the JIT mitigates some of the slowness of recast).

The bad news: this doesn't actaully work, because (surprise, surprise) we actually do use some of the modification features of recast. When these are used, we don't know how to reprint.

```
$ ag --ignore __tests__ builders\\.
src/utils/normalizeClassDefinition.js
79:            var classProperty = builders.classProperty(

src/utils/resolveObjectKeysToArray.js
98:        .map(value => builders.literal(value))
100:      return new NodePath(builders.arrayExpression(nodes));

src/utils/resolveToValue.js
33:        builders.memberExpression(
```

Maybe we could reimplement a small subset of the printing logic? Or maybe that's too impractical. FWIW all but one of the 700 files I tested produced the exact same output including whitespace in the `raw` JS source fields.