### PR TITLE
Support deep objects with spread flow types

### DIFF
--- a/src/handlers/flowTypeHandler.js
+++ b/src/handlers/flowTypeHandler.js
@@ -40,6 +40,6 @@ export default function flowTypeHandler(documentation: Documentation, path: Node
   }
 
   applyToFlowTypeProperties(flowTypesPath, propertyPath => {
-      setPropDescriptor(documentation, propertyPath)
+    setPropDescriptor(documentation, propertyPath)
   });
 }

--- a/src/utils/__tests__/getFlowType-test.js
+++ b/src/utils/__tests__/getFlowType-test.js
@@ -232,6 +232,39 @@ describe('getFlowType', () => {
     }, raw: '{ a: string, b: ?xyz }'});
   });
 
+  it('handles ObjectTypeSpreadProperty', () => {
+    var typePath = statement(`
+      var x: { ...OtherProps, ...MyType, a: string };
+
+      type MyType = { myString: string };
+    `).get('declarations', 0).get('id').get('typeAnnotation').get('typeAnnotation');
+
+    expect(getFlowType(typePath)).toEqual({
+      name: 'signature',
+      type: 'object',
+      signature: {
+        inheritedProperties: [
+          { name: 'OtherProps', value: { name: 'OtherProps' } },
+          { name: 'MyType',
+            value: {
+              name: 'signature',
+              type: 'object',
+              signature: {
+                properties: [
+                  { key: 'myString', value: { name: 'string', required: true } },
+                ],
+              },
+              raw: '{ myString: string }',
+            },
+          },
+        ],
+        properties: [
+          { key: 'a', value: { name: 'string', required: true } },
+        ],
+      },
+      raw: '{ ...OtherProps, ...MyType, a: string }'});
+  });
+
   describe('React types', () => {
     function test(type, expected) {
       var typePath = statement(`


### PR DESCRIPTION
This handles props where a value in that type is a object which contains spread types.

Requires the changes in #241 
  