### PR TITLE
Ignore ObjectTypeSpreadProperty

### DIFF
--- a/src/__tests__/fixtures/component_11.js
+++ b/src/__tests__/fixtures/component_11.js
@@ -14,7 +14,23 @@
 
 import React from 'react';
 
+import { OtherComponentProps } from 'NonExistentFile';
+
+type OtherLocalProps = {|
+  fooProp: string,
+|}
+
 type Props = {|
+  /**
+   * Spread props defined locally
+   */
+  ...OtherLocalProps,
+
+  /**
+   * Spread props from another file
+   */
+  ...OtherComponentProps,
+
   /**
    * The first prop
    */

--- a/src/utils/getFlowTypeFromReactComponent.js
+++ b/src/utils/getFlowTypeFromReactComponent.js
@@ -74,7 +74,11 @@ export function applyToFlowTypeProperties(
 ) {
   if (path.node.properties) {
     path.get('properties').each(
-      propertyPath => callback(propertyPath)
+      (propertyPath) => {
+        if (types.ObjectTypeProperty.check(propertyPath.node)) {
+          callback(propertyPath);
+        }
+      }
     );
   } else if (path.node.type === 'IntersectionTypeAnnotation') {
     path.get('types').each(


### PR DESCRIPTION
This is the simplest way to ignore object type spread properties and have react-docgen not blow up. 

Without this change an exception would throw saying `Propery name must be an Identifier or a Literal`. 

Since this PR ignores the spread types, they don't show up in the output. There are other PRs to add that functionality once we figure out the ideal output structure: #241 #242 