### PR TITLE
add context handlers

### DIFF
--- a/src/Documentation.js
+++ b/src/Documentation.js
@@ -12,11 +12,15 @@
 
 class Documentation {
   _props: Object;
+  _context: Object;
+  _childContext: Object;
   _composes: Set<string>;
   _data: Object;
 
   constructor() {
     this._props = new Map();
+    this._context = new Map();
+    this._childContext = new Map();
     this._composes = new Set();
     this._data = new Map();
   }
@@ -41,6 +45,22 @@ class Documentation {
     return propDescriptor;
   }
 
+  getContextDescriptor(propName: string): PropDescriptor {
+    var propDescriptor = this._context.get(propName);
+    if (!propDescriptor) {
+      this._context.set(propName, propDescriptor = {});
+    }
+    return propDescriptor;
+  }
+
+  getChildContextDescriptor(propName: string): PropDescriptor {
+    var propDescriptor = this._childContext.get(propName);
+    if (!propDescriptor) {
+      this._childContext.set(propName, propDescriptor = {});
+    }
+    return propDescriptor;
+  }
+
   toObject(): Object {
     var obj = {};
 
@@ -52,6 +72,20 @@ class Documentation {
       obj.props = {};
       for (var [name, descriptor] of this._props) {
         obj.props[name] = descriptor;
+      }
+    }
+
+    if (this._context.size > 0) {
+      obj.context = {};
+      for (var [name, descriptor] of this._context) {
+        obj.context[name] = descriptor;
+      }
+    }
+
+    if (this._childContext.size > 0) {
+      obj.childContext = {};
+      for (var [name, descriptor] of this._childContext) {
+        obj.childContext[name] = descriptor;
       }
     }
 

--- a/src/Documentation.js
+++ b/src/Documentation.js
@@ -70,22 +70,22 @@ class Documentation {
 
     if (this._props.size > 0) {
       obj.props = {};
-      for (var [name, descriptor] of this._props) {
-        obj.props[name] = descriptor;
+      for (var [propName, propDescriptor] of this._props) {
+        obj.props[propName] = propDescriptor;
       }
     }
 
     if (this._context.size > 0) {
       obj.context = {};
-      for (var [name, descriptor] of this._context) {
-        obj.context[name] = descriptor;
+      for (var [contextName, contextDescriptor] of this._context) {
+        obj.context[contextName] = contextDescriptor;
       }
     }
 
     if (this._childContext.size > 0) {
       obj.childContext = {};
-      for (var [name, descriptor] of this._childContext) {
-        obj.childContext[name] = descriptor;
+      for (var [childContextName, childContextDescriptor] of this._childContext) {
+        obj.childContext[childContextName] = childContextDescriptor;
       }
     }
 

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -102,6 +102,22 @@ Object {
 
 exports[`main fixtures processes component "component_5.js" without errors 1`] = `
 Object {
+  "childContext": Object {
+    "color": Object {
+      "required": false,
+      "type": Object {
+        "name": "string",
+      },
+    },
+  },
+  "context": Object {
+    "config": Object {
+      "required": false,
+      "type": Object {
+        "name": "object",
+      },
+    },
+  },
   "description": "",
   "displayName": "Button",
   "methods": Array [],
@@ -137,6 +153,22 @@ Object {
 
 exports[`main fixtures processes component "component_6.js" without errors 1`] = `
 Object {
+  "childContext": Object {
+    "color": Object {
+      "required": false,
+      "type": Object {
+        "name": "string",
+      },
+    },
+  },
+  "context": Object {
+    "config": Object {
+      "required": false,
+      "type": Object {
+        "name": "object",
+      },
+    },
+  },
   "description": "",
   "displayName": "Button",
   "methods": Array [],

--- a/src/__tests__/fixtures/component_5.js
+++ b/src/__tests__/fixtures/component_5.js
@@ -15,4 +15,12 @@ Button.propTypes = {
   style: React.PropTypes.object,
 };
 
+Button.childContextTypes = {
+  color: React.PropTypes.string,
+};
+
+Button.contextTypes = {
+  config: React.PropTypes.object,
+};
+
 export default Button;

--- a/src/__tests__/fixtures/component_6.js
+++ b/src/__tests__/fixtures/component_6.js
@@ -16,4 +16,11 @@ Button.propTypes = {
   style: PropTypes.object,
 };
 
+Button.childContextTypes = {
+  color: PropTypes.string,
+};
+
+Button.contextTypes = {
+  config: PropTypes.object,
+};
 export default Button;

--- a/src/handlers/__tests__/propTypeHandler-test.js
+++ b/src/handlers/__tests__/propTypeHandler-test.js
@@ -15,7 +15,7 @@ jest.mock('../../utils/getPropType', () => jest.fn(() => ({})));
 
 import {statement, expression} from '../../../tests/utils';
 import Documentation from '../../Documentation';
-import propTypeHandler from '../propTypeHandler';
+import {propTypeHandler} from '../propTypeHandler';
 
 describe('propTypeHandler', () => {
   var getPropTypeMock;

--- a/src/handlers/index.js
+++ b/src/handlers/index.js
@@ -15,7 +15,7 @@ export {default as componentDocblockHandler} from './componentDocblockHandler';
 export {default as componentMethodsHandler} from './componentMethodsHandler';
 export {default as componentMethodsJsDocHandler} from './componentMethodsJsDocHandler';
 export {default as defaultPropsHandler} from './defaultPropsHandler';
-export {default as propTypeHandler} from './propTypeHandler';
+export {propTypeHandler, contextTypeHandler, childContextTypeHandler} from './propTypeHandler';
 export {default as propTypeCompositionHandler} from './propTypeCompositionHandler';
 export {default as propDocBlockHandler} from './propDocBlockHandler';
 export {default as displayNameHandler} from './displayNameHandler';

--- a/src/handlers/propTypeHandler.js
+++ b/src/handlers/propTypeHandler.js
@@ -67,7 +67,7 @@ function amendPropTypes(getDescriptor, path) {
   });
 }
 
-export function getPropTypeHandler(propName: string) {
+function getPropTypeHandler(propName: string) {
   return function (
     documentation: Documentation,
     path: NodePath

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,8 @@ import * as utils from './utils';
 var defaultResolver = resolver.findExportedComponentDefinition;
 var defaultHandlers = [
   handlers.propTypeHandler,
+  handlers.contextTypeHandler,
+  handlers.childContextTypeHandler,
   handlers.propTypeCompositionHandler,
   handlers.propDocBlockHandler,
   handlers.flowTypeHandler,


### PR DESCRIPTION
Hi,

this PR builds up on the PR #130 that didn't show any activity for about a year now.

It introduces two new handlers for `contextType` and `childContextType` based on existing `propTypeHandler`.

I've rebased the stale branch, updated 2 fixtures  and snapshots (as was requested in the above PR) and also fixed some linter errors. Let me know if any other changes are required, please.

Thanks,
G.