### PR TITLE
Add ability to detect "required" on shapes

### DIFF
--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -73,6 +73,7 @@ Object {
       "type": Object {
         "computed": true,
         "name": "shape",
+        "required": true,
         "value": "Child.propTypes",
       },
     },
@@ -81,6 +82,7 @@ Object {
       "required": true,
       "type": Object {
         "name": "shape",
+        "required": true,
         "value": Object {
           "adopted": Object {
             "name": "bool",

--- a/src/utils/getPropType.js
+++ b/src/utils/getPropType.js
@@ -196,6 +196,7 @@ export default function getPropType(path: NodePath): PropTypeDescriptor {
         return true;
       } else if (propTypes.hasOwnProperty(name) && member.argumentsPath) {
         descriptor = propTypes[name](member.argumentsPath.get(0));
+        descriptor.required = isRequiredPropType(path);
         return true;
       }
     }
@@ -209,6 +210,7 @@ export default function getPropType(path: NodePath): PropTypeDescriptor {
         types.Identifier.check(node.callee) &&
         propTypes.hasOwnProperty(node.callee.name)) {
       descriptor = propTypes[node.callee.name](path.get('arguments', 0));
+      descriptor.required = isRequiredPropType(path);
     } else {
       descriptor = {name: 'custom', raw: printValue(path)};
     }


### PR DESCRIPTION
This is something that's causing us troubles when creating our styleguide. React Docgen does not detect shapes or enums as required or not.

This PR adds the support. What I've done

- Added and updated tests
- Made sure lint rules were fine

It's my first time contributing to this repo so please let me know If I am doing something wrong.

Thanks! 👋