### PR TITLE
Allow for programmatic usage of "react-docgen" binary features

### DIFF
--- a/bin/react-docgen.js
+++ b/bin/react-docgen.js
@@ -105,22 +105,25 @@ const parser = new ParseStream({
  * 1. No files passed, consume input stream
  */
 if (!Array.isArray(argv.args) || !argv.args.length) {
-  // var source = '';
-  // process.stdin.setEncoding('utf8');
-  // process.stdin.resume();
-  // var timer = setTimeout(function() {
-  //   process.stderr.write('Still waiting for std input...');
-  // }, 5000);
-  // process.stdin.on('data', function (chunk) {
-  //   clearTimeout(timer);
-  //   source += chunk;
-  // });
-  // process.stdin.on('end', function () {
-  //   try {
-  //     writeResult(parse(source));
-  //   } catch(error) {
-  //     writeError(error);
-  //   }
-  // });
+  let source = '';
+
+  process.stdin.setEncoding('utf8');
+  process.stdin.resume();
+
+  const timer = setTimeout(function() {
+    process.stderr.write('Still waiting for std input...');
+  }, 5000);
+  process.stdin.on('data', function (chunk) {
+    clearTimeout(timer);
+    source += chunk;
+  });
+
+  process.stdin.on('end', function () {
+    try {
+      writeResult(parser.parse(source));
+    } catch(error) {
+      writeWarning({ error });
+    }
+  });
 }
 

--- a/bin/react-docgen.js
+++ b/bin/react-docgen.js
@@ -9,7 +9,8 @@
  *
  */
 
-var argv = require('commander');
+const argv = require('commander');
+const ParseStream = require('../dist/parse-stream').default;
 
 function collect(val, memo) {
   memo.push(val);
@@ -21,206 +22,105 @@ var defaultExclude = [];
 var defaultIgnore = ['node_modules', '__tests__', '__mocks__'];
 
 argv
-    .usage('[path...] [options]')
-    .description(
-        'Extract meta information from React components.\n' +
-        '  If a directory is passed, it is recursively traversed.')
-    .option(
-        '-o, --out <file>',
-        'Store extracted information in the FILE')
-    .option(
-        '--pretty',
-        'pretty print JSON')
-    .option(
-        '-x, --extension <extension>',
-        'File extensions to consider. Repeat to define multiple extensions. Default: ' + JSON.stringify(defaultExtensions),
-        collect,
-        ['js', 'jsx'])
-    .option(
-        '-e, --exclude <path>',
-        'Filename or regex to exclude. Default: ' + JSON.stringify(defaultExclude),
-        collect,
-        [])
-    .option(
-        '-i, --ignore <path>',
-        'Folders to ignore. Default: ' + JSON.stringify(defaultIgnore),
-        collect,
-        ['node_modules', '__tests__', '__mocks__'])
-    .option(
-        '--resolver <resolver>',
-        'Resolver name (findAllComponentDefinitions, findExportedComponentDefinition) or path to a module that exports ' +
-        'a resolver. Default: findExportedComponentDefinition',
-        'findExportedComponentDefinition')
-    .arguments('<path>');
+  .usage('[path...] [options]')
+  .description(
+    'Extract meta information from React components.\n' +
+    '  If a directory is passed, it is recursively traversed.')
+  .option(
+    '-o, --out <file>',
+    'Store extracted information in the FILE')
+  .option(
+    '--pretty',
+    'pretty print JSON')
+  .option(
+    '-x, --extension <extension>',
+    'File extensions to consider. Repeat to define multiple extensions. Default: ' + JSON.stringify(defaultExtensions),
+    collect,
+    ['js', 'jsx'])
+  .option(
+    '-e, --exclude <path>',
+    'Filename or regex to exclude. Default: ' + JSON.stringify(defaultExclude),
+    collect,
+    [])
+  .option(
+    '-i, --ignore <path>',
+    'Folders to ignore. Default: ' + JSON.stringify(defaultIgnore),
+    collect,
+    ['node_modules', '__tests__', '__mocks__'])
+  .option(
+    '--resolver <resolver>',
+    'Resolver name (findAllComponentDefinitions, findExportedComponentDefinition) or path to a module that exports ' +
+    'a resolver. Default: findExportedComponentDefinition',
+    'findExportedComponentDefinition')
+  .arguments('<path>');
 
 argv.parse(process.argv);
 
-var async = require('async');
-var dir = require('node-dir');
-var fs = require('fs');
-var parser = require('../dist/main');
-var path = require('path');
-
-var output = argv.out;
-var paths = argv.args || [];
-var extensions = new RegExp('\\.(?:' + argv.extension.join('|') + ')$');
-var ignoreDir = argv.ignore;
-var excludePatterns = argv.exclude;
-var resolver;
-var errorMessage;
-var regexRegex = /^\/(.*)\/([igymu]{0,5})$/;
-if (excludePatterns && excludePatterns.length === 1 && regexRegex.test(excludePatterns[0])){
-  var match = excludePatterns[0].match(regexRegex);
-    excludePatterns = new RegExp(match[1], match[2]);
-}
-
-if (argv.resolver) {
-  try {
-    // Look for built-in resolver
-    resolver = require(`../dist/resolver/${argv.resolver}`).default;
-  } catch(e) {
-    if (e.code !== 'MODULE_NOT_FOUND') {
-      throw e;
-    }
-    const resolverPath = path.resolve(process.cwd(), argv.resolver);
-    try {
-      // Look for local resolver
-      resolver = require(resolverPath);
-    } catch (e) {
-      if (e.code !== 'MODULE_NOT_FOUND') {
-        throw e;
-      }
-      // Will exit with this error message
-      errorMessage = (
-        `Unknown resolver: "${argv.resolver}" is neither a built-in resolver ` +
-        `nor can it be found locally ("${resolverPath}")`
-      );
-    }
-  }
-}
-
-function parse(source) {
-  return parser.parse(source, resolver);
-}
-
-function writeError(msg, filePath) {
+function writeWarning(warning) {
+  const { filePath, error, where } = warning;
   if (filePath) {
     process.stderr.write('Error with path "' + filePath + '": ');
   }
-  process.stderr.write(msg + '\n');
-  if (msg instanceof Error) {
-    process.stderr.write(msg.stack + '\n');
+
+  process.stderr.write(error + '\n');
+  if (error instanceof Error) {
+    process.stderr.write(error.stack + '\n');
   }
 }
 
-function writeResult(result) {
-  result = argv.pretty ?
+function writeResult() {
+  const text = pretty ?
     JSON.stringify(result, null, 2) :
     JSON.stringify(result);
+
   if (output) {
-    fs.writeFileSync(output, result);
+    fs.writeFileSync(output, text);
   } else {
-    process.stdout.write(result + '\n');
+    process.stdout.write(text + '\n');
   }
 }
 
-function traverseDir(filePath, result, done) {
-  dir.readFiles(
-    filePath,
-    {
-      match: extensions,
-      exclude:excludePatterns,
-      excludeDir: ignoreDir,
-    },
-    function(error, content, filename, next) {
-      if (error) {
-        throw error;
-      }
-      try {
-        result[filename] = parse(content);
-      } catch(error) {
-        writeError(error, filename);
-      }
-      next();
-    },
-    function(error) {
-      if (error) {
-        throw error;
-      }
-      done();
-    }
-  );
-}
+const pretty = argv.pretty;
+const output = argv.out;
+const result = {};
+
+// Setup the ParseStream and handle the output
+const parser = new ParseStream({
+  exclude: argv.exclude,
+  extension: argv.extension,
+  ignore: argv.ignore,
+  paths: argv.args || [],
+  resolver: argv.resolver
+})
+.on('warning', writeWarning)
+.on('end', writeResult)
+.on('error', err => { throw err })
+.on('readable', () => {
+  while (data = parser.read()) {
+    result[data.file] = data.ast;
+  }
+});
 
 /**
- * 1. An error occurred, so exit
+ * 1. No files passed, consume input stream
  */
-if (errorMessage) {
-  writeError(errorMessage);
-  process.exitCode = 1;
-} else if (paths.length === 0) {
-  /**
-   * 2. No files passed, consume input stream
-   */
-  var source = '';
-  process.stdin.setEncoding('utf8');
-  process.stdin.resume();
-  var timer = setTimeout(function() {
-    process.stderr.write('Still waiting for std input...');
-  }, 5000);
-  process.stdin.on('data', function (chunk) {
-    clearTimeout(timer);
-    source += chunk;
-  });
-  process.stdin.on('end', function () {
-    try {
-      writeResult(parse(source));
-    } catch(error) {
-      writeError(error);
-    }
-  });
-} else {
-  /**
-   * 3. Paths are passed
-   */
-  var result = Object.create(null);
-  async.eachSeries(paths, function(filePath, done) {
-    fs.stat(filePath, function(error, stats) {
-      if (error) {
-        writeError(error, filePath);
-        done();
-        return;
-      }
-      if (stats.isDirectory()) {
-        try {
-          traverseDir(filePath, result, done);
-        } catch(error) {
-          writeError(error);
-          done();
-        }
-      }
-      else {
-        try {
-          result[filePath] = parse(fs.readFileSync(filePath));
-        } catch(error) {
-          writeError(error, filePath);
-        }
-        finally {
-          done();
-        }
-      }
-    });
-  }, function() {
-    var resultsPaths = Object.keys(result);
-    if (resultsPaths.length === 0) {
-      // we must have gotten an error
-      process.exitCode = 1;
-    } else if (paths.length === 1) { // a single path?
-      fs.stat(paths[0], function(error, stats) {
-        writeResult(stats.isDirectory() ? result : result[resultsPaths[0]]);
-      });
-    } else {
-      writeResult(result);
-    }
-  });
+if (!Array.isArray(argv.args) || !argv.args.length) {
+  // var source = '';
+  // process.stdin.setEncoding('utf8');
+  // process.stdin.resume();
+  // var timer = setTimeout(function() {
+  //   process.stderr.write('Still waiting for std input...');
+  // }, 5000);
+  // process.stdin.on('data', function (chunk) {
+  //   clearTimeout(timer);
+  //   source += chunk;
+  // });
+  // process.stdin.on('end', function () {
+  //   try {
+  //     writeResult(parse(source));
+  //   } catch(error) {
+  //     writeError(error);
+  //   }
+  // });
 }
+

--- a/src/parse-stream.js
+++ b/src/parse-stream.js
@@ -29,7 +29,7 @@ export default class ParseStream extends Transform {
     // Handle regular expression syntax passed for exclude
     let exclude = opts.exclude;
     if (exclude && exclude.length === 1 && regexRegex.test(exclude[0])) {
-      const match = excludePatterns[0].match(regexRegex);
+      const match = exclude[0].match(regexRegex);
       exclude = new RegExp(match[1], match[2]);
     }
 

--- a/src/parse-stream.js
+++ b/src/parse-stream.js
@@ -1,0 +1,137 @@
+import { Transform } from 'stream';
+import async from 'async';
+import dir from 'node-dir';
+import fs  from 'fs';
+import * as parser from './main';
+import path from 'path';
+
+const regexRegex = /^\/(.*)\/([igymu]{0,5})$/;
+
+export default class ParseStream extends Transform {
+  _sourceDir: string;
+  _paths: Array<string>;
+  _resolver: string;
+  _outFile: string;
+  _extension: string;
+  _exclude: string;
+  _ignore: string;
+
+  constructor(opts) {
+    super({ objectMode: true });
+
+    const {
+      extension,
+      ignore,
+      paths,
+      resolver
+    } = opts
+
+    // Handle regular expression syntax passed for exclude
+    let exclude = opts.exclude;
+    if (exclude && exclude.length === 1 && regexRegex.test(exclude[0])) {
+      const match = excludePatterns[0].match(regexRegex);
+      exclude = new RegExp(match[1], match[2]);
+    }
+
+    this._extensions = new RegExp('\\.(?:' + extension.join('|') + ')$');
+    this._excludePatterns = exclude;
+    this._ignoreDir = ignore;
+    this._paths = paths;
+
+    if (resolver) {
+      try {
+        // Look for built-in resolver
+        this._resolver = require(`../dist/resolver/${resolver}`).default;
+      } catch(e) {
+        if (e.code !== 'MODULE_NOT_FOUND') {
+          throw e;
+        }
+
+        const resolverPath = path.resolve(process.cwd(), resolver);
+        try {
+          // Look for local resolver
+          this._resolver = require(resolverPath);
+        } catch (e) {
+          if (e.code !== 'MODULE_NOT_FOUND') {
+            throw e;
+          }
+
+          // Will exit with this error message
+          throw new Error(
+            `Unknown resolver: "${resolver}" is neither a built-in resolver ` +
+            `nor can it be found locally ("${resolverPath}")`
+          );
+        }
+      }
+    }
+
+    // If a set of file paths are provided then in the next tick begin
+    // reading from them and automatically end this instance when
+    // complete.
+    if (Array.isArray(this._paths) && this._paths.length) {
+      setImmediate(() => this.traverse(() => {
+        this.end();
+      }));
+    }
+  }
+
+  parse(source) {
+    return parser.parse(source, this._resolver);
+  }
+
+  traverse(done = function () {}) {
+    async.eachSeries(this._paths, (filePath, next) => {
+      fs.stat(filePath, (error, stats) => {
+        if (error) {
+          this.emit('warning', { error, filePath, where: 'stat' });
+          return next();
+        }
+
+        if (stats.isDirectory()) {
+          return this.traverseDir(filePath, (error) => {
+            if (error) {
+              this.emit('warning', { error, filePath, where: 'traverseDir' });
+            }
+
+            next();
+          });
+        }
+
+        try {
+          const ast = this.parse(fs.readFileSync(filePath));
+          this.push({ file: filePath, ast });
+        } catch(error) {
+          this.emit('warning', { error, filePath, where: 'parse' });
+        } finally {
+          next();
+        }
+      });
+    }, done);
+  }
+
+  traverseDir(filePath, done) {
+    dir.readFiles(
+      filePath,
+      {
+        match: this._extensions,
+        exclude: this._excludePatterns,
+        excludeDir: this._ignoreDir,
+      },
+      (error, content, filename, next) => {
+        if (error) {
+          return next(error);
+        }
+
+        try {
+          const ast = this.parse(content);
+          this.push({ file: filename, ast });
+        } catch(error) {
+          this.emit('warning', { error, filePath, where: 'parse' });
+        }
+
+        next();
+      },
+      done
+    );
+  }
+}


### PR DESCRIPTION
Howdy! Doing some fancy(ish) traversals of a bunch of `react` components using `react-docgen` and realized that I was re-implementing a lot of the functionality in the core binary – so figured it would be worth while to see if making the binary into a Node stream is desirable.

- [x] **Create `src/parse-stream.js`:** a Node.js `Transform` stream in `objectMode`. If `{ paths }` are provided to a new `ParseStream` it begins the directory traversal in the next tick and emits Objects with this API:
``` js
{ file: '/path/to/component.js', ast: /* parsed AST */ }
```
- [x] **Ensure 100% non-breaking with existing CLI:** conforms to the existing CLI API, just refactoring under the covers so folks can do things like this and have strong guarantees of compatibility in the future. 
``` js
import { ParseStream } from 'react-docgen';
new ParseStream(/* opts */).on('readable', () => {});
```
- [ ] **Updates tests & docs:** not there yet (wants to get input first before wrapping it up), but if you folks are 👍on the change I'll fix all those up. Right now 7/14 the tests in `bin/__tests__` are passing.