### PR TITLE
Adding `@extends React.Component` support to isReactComponentClass

### DIFF
--- a/src/utils/__tests__/isReactComponentClass-test.js
+++ b/src/utils/__tests__/isReactComponentClass-test.js
@@ -52,6 +52,21 @@ describe('isReactComponentClass', () => {
     });
   });
 
+  describe('JSDoc @extends React.Component', () => {
+    it('accepts class declarations declaring `@extends React.Component` in JSDoc', () => {
+      var def = parse(`
+        var React = require('react');
+        /**
+         * @class Foo
+         * @extends React.Component 
+         */
+        class Foo extends Bar {}
+      `).get('body', 1);
+
+      expect(isReactComponentClass(def)).toBe(true);
+    });
+  });
+
   describe('React.Component inheritance', () => {
     it('accepts class declarations extending React.Component', () => {
       var def = parse(`

--- a/src/utils/isReactComponentClass.js
+++ b/src/utils/isReactComponentClass.js
@@ -46,7 +46,7 @@ export default function isReactComponentClass(
 
   // check for @extends React.Component in docblock
   if (path.parentPath.value && path.parentPath.value) {
-    var classDeclaration;
+    var classDeclaration = {};
     if (Array.isArray(path.parentPath.value)) {
       var matches = path.parentPath.value.filter(function(declaration) { return declaration.type === 'ClassDeclaration' });
       if (matches[0]) {

--- a/src/utils/isReactComponentClass.js
+++ b/src/utils/isReactComponentClass.js
@@ -58,9 +58,8 @@ export default function isReactComponentClass(
     
     if (classDeclaration &&
       classDeclaration.leadingComments &&
-      classDeclaration.leadingComments.length &&
       classDeclaration.leadingComments.some(function (comment) {
-      return /@extends\s+React\.Component/.test(comment.value);
+        return /@extends\s+React\.Component/.test(comment.value);
       })) {
       return true;
     }

--- a/src/utils/isReactComponentClass.js
+++ b/src/utils/isReactComponentClass.js
@@ -44,6 +44,26 @@ export default function isReactComponentClass(
     return true;
   }
 
+  // check for @extends React.Component in docblock
+  if (path.parentPath.value && path.parentPath.value) {
+    var classDeclaration;
+    if (Array.isArray(path.parentPath.value)) {
+      var matches = path.parentPath.value.filter(function(declaration) { return declaration.type === 'ClassDeclaration' });
+      if (matches[0]) {
+        classDeclaration = matches[0];
+      }
+    } else {
+      classDeclaration = path.parentPath.value;
+    }
+    
+    if (classDeclaration.leadingComments && classDeclaration.leadingComments.length > 0) {
+      var matchedComments = classDeclaration.leadingComments.filter(function(comment) { return comment.value.match(/(@extends React.Component)/) });
+      if (matchedComments.length > 0) {
+        return true;
+      }
+    }
+  }
+
   // extends ReactComponent?
   if (!node.superClass) {
     return false;

--- a/src/utils/isReactComponentClass.js
+++ b/src/utils/isReactComponentClass.js
@@ -46,15 +46,9 @@ export default function isReactComponentClass(
 
   // check for @extends React.Component in docblock
   if (path.parentPath && path.parentPath.value) {
-    var classDeclaration;
-    if (Array.isArray(path.parentPath.value)) {
-      var matches = path.parentPath.value.filter(function(declaration) { return declaration.type === 'ClassDeclaration' });
-      if (matches[0]) {
-        classDeclaration = matches[0];
-      }
-    } else {
-      classDeclaration = path.parentPath.value;
-    }
+    var classDeclaration = Array.isArray(path.parentPath.value)
+      ? path.parentPath.value.find(function(declaration) { return declaration.type === 'ClassDeclaration' })
+      : path.parentPath.value;
     
     if (classDeclaration &&
       classDeclaration.leadingComments &&

--- a/src/utils/isReactComponentClass.js
+++ b/src/utils/isReactComponentClass.js
@@ -45,8 +45,8 @@ export default function isReactComponentClass(
   }
 
   // check for @extends React.Component in docblock
-  if (path.parentPath.value && path.parentPath.value) {
-    var classDeclaration = {};
+  if (path.parentPath && path.parentPath.value) {
+    var classDeclaration;
     if (Array.isArray(path.parentPath.value)) {
       var matches = path.parentPath.value.filter(function(declaration) { return declaration.type === 'ClassDeclaration' });
       if (matches[0]) {
@@ -56,11 +56,13 @@ export default function isReactComponentClass(
       classDeclaration = path.parentPath.value;
     }
     
-    if (classDeclaration.leadingComments && classDeclaration.leadingComments.length > 0) {
-      var matchedComments = classDeclaration.leadingComments.filter(function(comment) { return comment.value.match(/(@extends React.Component)/) });
-      if (matchedComments.length > 0) {
-        return true;
-      }
+    if (classDeclaration &&
+      classDeclaration.leadingComments &&
+      classDeclaration.leadingComments.length &&
+      classDeclaration.leadingComments.some(function (comment) {
+      return /@extends\s+React\.Component/.test(comment.value);
+      })) {
+      return true;
     }
   }
 


### PR DESCRIPTION
Certain react components may have multiple layers of inheritance and don't necessarily have a render function if it has a base class that handles rendering. In that case, `react-docgen` would fail to parse the file.

This PR:
- [x] Adds support for `@extends React.Component` in the class-level JSDoc block
- [x] Adds a unit test to verify functionality