### PR TITLE
 Migrate babylon to @babel/parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `react-docgen` is a CLI and toolbox to help extracting information from [React][] components, and generate documentation from it.
 
-It uses [recast][] and [babylon][] to parse the source into an AST and provides methods to process this AST to extract the desired information. The output / return value is a JSON blob / JavaScript object.
+It uses [recast][] and [@babel/parser][] to parse the source into an AST and provides methods to process this AST to extract the desired information. The output / return value is a JSON blob / JavaScript object.
 
 It provides a default implementation for React components defined via
 `React.createClass`, [ES2015 class definitions][classes] or functions
@@ -381,5 +381,5 @@ The structure of the JSON blob / JavaScript object is as follows:
 [react]: http://facebook.github.io/react/
 [flow]: http://flowtype.org/
 [recast]: https://github.com/benjamn/recast
-[babylon]: https://github.com/babel/babylon
+[@babel/parser]: https://github.com/babel/babel/tree/master/packages/babel-parser
 [classes]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes

--- a/bin/react-docgen.js
+++ b/bin/react-docgen.js
@@ -42,6 +42,9 @@ argv
         collect,
         [])
     .option(
+        '--legacy-decorators',
+        'Enable parsing of legacy decorators proposal. By default only the new decorators syntax will be parsable.')
+    .option(
         '-i, --ignore <path>',
         'Folders to ignore. Default: ' + JSON.stringify(defaultIgnore),
         collect,
@@ -100,7 +103,7 @@ if (argv.resolver) {
 }
 
 function parse(source) {
-  return parser.parse(source, resolver);
+  return parser.parse(source, resolver, null, { legacyDecorators: argv.legacyDecorators });
 }
 
 function writeError(msg, filePath) {

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   "author": "Felix Kling",
   "license": "BSD-3-Clause",
   "dependencies": {
+    "@babel/parser": "7.0.0-beta.48",
     "async": "^2.1.4",
     "babel-runtime": "^6.9.2",
-    "babylon": "7.0.0-beta.44",
     "commander": "^2.9.0",
     "doctrine": "^2.0.0",
     "node-dir": "^0.1.10",

--- a/src/babelParser.js
+++ b/src/babelParser.js
@@ -8,7 +8,7 @@
  *
  */
 
-var babylon = require('babylon');
+var parser = require('@babel/parser');
 
 var options = {
   sourceType: 'module',
@@ -23,7 +23,8 @@ var options = {
     'classProperties',
     'classPrivateProperties',
     'classPrivateMethods',
-    'exportExtensions',
+    'exportDefaultFrom',
+    'exportNamespaceFrom',
     'asyncGenerators',
     'functionBind',
     'functionSent',
@@ -41,7 +42,7 @@ var options = {
 
 export default {
   parse(src) {
-    var file = babylon.parse(src, options);
+    var file = parser.parse(src, options);
     file.program.comments = file.comments;
     return file.program;
   },

--- a/src/babelParser.js
+++ b/src/babelParser.js
@@ -1,16 +1,18 @@
 /*
- *  Copyright (c) 2015, Facebook, Inc.
- *  All rights reserved.
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
  *
- *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant
- *  of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
  *
  */
 
 var parser = require('@babel/parser');
 
-var options = {
+var babelParserOptions = {
   sourceType: 'module',
   strictMode: false,
   plugins: [
@@ -19,7 +21,6 @@ var options = {
     'estree',
     'doExpressions',
     'objectRestSpread',
-    'decorators',
     'classProperties',
     'classPrivateProperties',
     'classPrivateMethods',
@@ -40,10 +41,29 @@ var options = {
   ],
 };
 
-export default {
-  parse(src) {
-    var file = parser.parse(src, options);
-    file.program.comments = file.comments;
-    return file.program;
-  },
+export type Options = {
+  legacyDecorators ?: boolean,
 };
+
+function buildOptions(options?: Options = {}) {
+  const parserOptions = { ...babelParserOptions, plugins: [...babelParserOptions.plugins] };
+  if (options.legacyDecorators) {
+    parserOptions.plugins.push('decorators-legacy');
+  } else {
+    parserOptions.plugins.push('decorators');
+  }
+
+  return parserOptions;
+}
+
+export default function buildParse(options: Options) {
+  const parserOptions = buildOptions(options);
+
+  return {
+    parse(src: string) {
+      var file = parser.parse(src, parserOptions);
+      file.program.comments = file.comments;
+      return file.program;
+    },
+  };
+}

--- a/src/handlers/__tests__/componentDocblockHandler-test.js
+++ b/src/handlers/__tests__/componentDocblockHandler-test.js
@@ -89,7 +89,7 @@ describe('componentDocblockHandler', () => {
    * Decorates can only be assigned to class and therefore only make sense for
    * class declarations and export declarations.
    */
-  function testDecorators(definitionSrc, parse) { // eslint-disable-line no-shadow
+  function testDecorators(classSrc, parse, exportSrc = '') { // eslint-disable-line no-shadow
     describe('decorators', () => {
       it('uses the docblock above the decorator if it\'s the only one', () => {
         var definition = parse(`
@@ -97,9 +97,10 @@ describe('componentDocblockHandler', () => {
           /**
            * Component description
            */
+          ${exportSrc}
           @Decorator1
           @Decorator2
-          ${definitionSrc}
+          ${classSrc}
         `);
 
         componentDocblockHandler(documentation, definition);
@@ -109,15 +110,17 @@ describe('componentDocblockHandler', () => {
       it('uses the component docblock if present', () => {
         var definition = parse(`
           import something from 'somewhere';
+
+          ${exportSrc}
           /**
-           * Decorator description
-           */
+          * Decorator description
+          */
           @Decorator1
           @Decorator2
           /**
            * Component description
            */
-          ${definitionSrc}
+          ${classSrc}
         `);
 
         componentDocblockHandler(documentation, definition);
@@ -181,8 +184,9 @@ describe('componentDocblockHandler', () => {
         src => lastStatement(src).get('declaration')
       );
       testDecorators(
-        'export default class Component {}',
-        src => lastStatement(src).get('declaration')
+        'class Component {}',
+        src => lastStatement(src).get('declaration'),
+        'export default'
       );
     });
 
@@ -192,8 +196,9 @@ describe('componentDocblockHandler', () => {
         src => lastStatement(src).get('declaration')
       );
       testDecorators(
-        'export default class {}',
-        src => lastStatement(src).get('declaration')
+        'class {}',
+        src => lastStatement(src).get('declaration'),
+        'export default'
       );
     });
 
@@ -241,8 +246,9 @@ describe('componentDocblockHandler', () => {
         src => lastStatement(src).get('declaration')
       );
       testDecorators(
-        'export class Component {}',
-        src => lastStatement(src).get('declaration')
+        'class Component {}',
+        src => lastStatement(src).get('declaration'),
+        'export'
       );
     });
 

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ import * as handlers from './handlers';
 import parse from './parse';
 import * as resolver from './resolver';
 import * as utils from './utils';
+import type { Options } from './babelParser';
 
 var defaultResolver = resolver.findExportedComponentDefinition;
 var defaultHandlers = [
@@ -45,7 +46,8 @@ var defaultHandlers = [
 function defaultParse( // eslint-disable-line no-unused-vars
   src: string,
   resolver?: ?Resolver, // eslint-disable-line no-shadow
-  handlers?: ?Array<Handler> // eslint-disable-line no-shadow
+  handlers?: ?Array<Handler>, // eslint-disable-line no-shadow
+  options ?: Options = {}
 ): Array<Object>|Object {
   if (!resolver) {
     resolver = defaultResolver;
@@ -54,7 +56,7 @@ function defaultParse( // eslint-disable-line no-unused-vars
     handlers = defaultHandlers;
   }
 
-  return parse(src, resolver, handlers);
+  return parse(src, resolver, handlers, options);
 }
 
 export {

--- a/src/parse.js
+++ b/src/parse.js
@@ -13,7 +13,7 @@
 import Documentation from './Documentation';
 import postProcessDocumentation from './utils/postProcessDocumentation';
 
-import babylon from './babylon';
+import parser from './babelParser';
 import recast from 'recast';
 
 var ERROR_MISSING_DEFINITION = 'No suitable component definition found.';
@@ -51,7 +51,7 @@ export default function parse(
   resolver: Resolver,
   handlers: Array<Handler>
 ): Array<Object>|Object {
-  var ast = recast.parse(src, {esprima: babylon});
+  var ast = recast.parse(src, {esprima: parser});
   var componentDefinitions = resolver(ast.program, recast);
 
   if (Array.isArray(componentDefinitions)) {

--- a/src/parse.js
+++ b/src/parse.js
@@ -13,7 +13,7 @@
 import Documentation from './Documentation';
 import postProcessDocumentation from './utils/postProcessDocumentation';
 
-import parser from './babelParser';
+import buildParser, { type Options } from './babelParser';
 import recast from 'recast';
 
 var ERROR_MISSING_DEFINITION = 'No suitable component definition found.';
@@ -49,9 +49,10 @@ function executeHandlers(handlers, componentDefinitions) {
 export default function parse(
   src: string,
   resolver: Resolver,
-  handlers: Array<Handler>
+  handlers: Array<Handler>,
+  options: Options
 ): Array<Object>|Object {
-  var ast = recast.parse(src, {esprima: parser});
+  var ast = recast.parse(src, { parser: buildParser(options) });
   var componentDefinitions = resolver(ast.program, recast);
 
   if (Array.isArray(componentDefinitions)) {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -3,7 +3,7 @@
  */
 
 import _recast from 'recast';
-import parser from '../src/babelParser';
+import buildParser from '../src/babelParser';
 
 function stringify(value) {
   if (Array.isArray(value)) {
@@ -15,9 +15,9 @@ function stringify(value) {
 /**
  * Returns a NodePath to the program node of the passed node
  */
-export function parse(src, recast=_recast) {
+export function parse(src, recast = _recast, options = {}) {
   return new recast.types.NodePath(
-    recast.parse(stringify(src), {esprima: parser}).program
+    recast.parse(stringify(src), { parser: buildParser(options) }).program
   );
 }
 

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -3,7 +3,7 @@
  */
 
 import _recast from 'recast';
-import babylon from '../src/babylon';
+import parser from '../src/babelParser';
 
 function stringify(value) {
   if (Array.isArray(value)) {
@@ -17,7 +17,7 @@ function stringify(value) {
  */
 export function parse(src, recast=_recast) {
   return new recast.types.NodePath(
-    recast.parse(stringify(src), {esprima: babylon}).program
+    recast.parse(stringify(src), {esprima: parser}).program
   );
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,6 +60,10 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@babel/parser@7.0.0-beta.48":
+  version "7.0.0-beta.48"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0-beta.48.tgz#f93895cbacee703c0ec98e5af3901c77edd9f1d7"
+
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
@@ -124,7 +128,16 @@ ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
 
-ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
+ajv@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.3.0.tgz#4414ff74a50879c208ee5fdc826e32c303549eda"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+
+ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:


### PR DESCRIPTION
Add option to switch back to legacy decorators parsing

This is a breaking change as it will by default only parse the latest decorators spec which changed the syntax.