### PR TITLE
fix: Correctly and recursively parse jsdoc types

### DIFF
--- a/src/handlers/__tests__/componentMethodsJsDocHandler-test.js
+++ b/src/handlers/__tests__/componentMethodsJsDocHandler-test.js
@@ -13,7 +13,7 @@
 import Documentation from '../../Documentation';
 import componentMethodsJsDocHandler from '../componentMethodsJsDocHandler';
 
-describe('componentMethodsHandler', () => {
+describe('componentMethodsJsDocHandler', () => {
   let documentation;
 
   beforeEach(() => {
@@ -76,6 +76,7 @@ describe('componentMethodsHandler', () => {
           {
             name: 'test',
             description: null,
+            optional: false,
             type: { name: 'string' },
           },
         ],
@@ -121,6 +122,7 @@ describe('componentMethodsHandler', () => {
           {
             name: 'test',
             description: null,
+            optional: false,
             type: { name: 'number' },
           },
         ],
@@ -166,6 +168,7 @@ describe('componentMethodsHandler', () => {
           {
             name: 'test',
             description: 'The test',
+            optional: false,
             type: null,
           },
         ],

--- a/src/utils/__tests__/__snapshots__/parseJsDoc-test.js.snap
+++ b/src/utils/__tests__/__snapshots__/parseJsDoc-test.js.snap
@@ -1,0 +1,189 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parseJsDoc @param extracts jsdoc description 1`] = `
+Object {
+  "description": null,
+  "params": Array [
+    Object {
+      "description": "test",
+      "name": "bar",
+      "optional": false,
+      "type": null,
+    },
+  ],
+  "returns": null,
+}
+`;
+
+exports[`parseJsDoc @param extracts jsdoc empty description 1`] = `
+Object {
+  "description": null,
+  "params": Array [
+    Object {
+      "description": null,
+      "name": "bar",
+      "optional": false,
+      "type": Object {
+        "name": "string",
+      },
+    },
+  ],
+  "returns": null,
+}
+`;
+
+exports[`parseJsDoc @param extracts jsdoc optional 1`] = `
+Object {
+  "description": null,
+  "params": Array [
+    Object {
+      "description": null,
+      "name": "bar",
+      "optional": true,
+      "type": Object {
+        "name": "string",
+      },
+    },
+  ],
+  "returns": null,
+}
+`;
+
+exports[`parseJsDoc @param extracts jsdoc typed array 1`] = `
+Object {
+  "description": null,
+  "params": Array [
+    Object {
+      "description": null,
+      "name": "bar",
+      "optional": false,
+      "type": Object {
+        "elements": Array [
+          Object {
+            "name": "string",
+          },
+          Object {
+            "name": "number",
+          },
+        ],
+        "name": "tuple",
+      },
+    },
+  ],
+  "returns": null,
+}
+`;
+
+exports[`parseJsDoc @param extracts jsdoc union type param 1`] = `
+Object {
+  "description": null,
+  "params": Array [
+    Object {
+      "description": null,
+      "name": "bar",
+      "optional": false,
+      "type": Object {
+        "elements": Array [
+          Object {
+            "name": "string",
+          },
+          Object {
+            "name": "Object",
+          },
+          Object {
+            "elements": Array [
+              Object {
+                "name": "some",
+              },
+            ],
+            "name": "Array",
+          },
+        ],
+        "name": "union",
+      },
+    },
+  ],
+  "returns": null,
+}
+`;
+
+exports[`parseJsDoc @returns extracts description from jsdoc 1`] = `
+Object {
+  "description": null,
+  "params": Array [],
+  "returns": Object {
+    "description": "The number",
+    "type": null,
+  },
+}
+`;
+
+exports[`parseJsDoc @returns extracts jsdoc mixed types 1`] = `
+Object {
+  "description": null,
+  "params": Array [],
+  "returns": Object {
+    "description": null,
+    "type": Object {
+      "name": "mixed",
+    },
+  },
+}
+`;
+
+exports[`parseJsDoc @returns extracts jsdoc typed array 1`] = `
+Object {
+  "description": null,
+  "params": Array [
+    Object {
+      "description": null,
+      "name": "bar",
+      "optional": false,
+      "type": Object {
+        "elements": Array [
+          Object {
+            "name": "string",
+          },
+          Object {
+            "name": "number",
+          },
+        ],
+        "name": "tuple",
+      },
+    },
+  ],
+  "returns": null,
+}
+`;
+
+exports[`parseJsDoc @returns extracts jsdoc types 1`] = `
+Object {
+  "description": null,
+  "params": Array [],
+  "returns": Object {
+    "description": null,
+    "type": Object {
+      "name": "string",
+    },
+  },
+}
+`;
+
+exports[`parseJsDoc @returns works with @return 1`] = `
+Object {
+  "description": null,
+  "params": Array [],
+  "returns": Object {
+    "description": "The number",
+    "type": null,
+  },
+}
+`;
+
+exports[`parseJsDoc description extracts the method description in jsdoc 1`] = `
+Object {
+  "description": "Don't use this!",
+  "params": Array [],
+  "returns": null,
+}
+`;

--- a/src/utils/__tests__/parseJsDoc-test.js
+++ b/src/utils/__tests__/parseJsDoc-test.js
@@ -24,150 +24,38 @@ describe('parseJsDoc', () => {
       const docblock = `
         Don't use this!
       `;
-      expect(parseJsDoc(docblock)).toEqual({
-        description: "Don't use this!",
-        returns: null,
-        params: [],
+      expect(parseJsDoc(docblock)).toMatchSnapshot();
+    });
+  });
+  describe('@param', () => {
+    const docBlocks = {
+      'extracts jsdoc description': '@param bar test',
+      'extracts jsdoc empty description': '@param {string} bar',
+      'extracts jsdoc union type param': '@param {string|Object|some[]} bar',
+      'extracts jsdoc optional': '@param {string=} bar',
+      'extracts jsdoc typed array': '@param {[string, number]} bar',
+    };
+
+    Object.keys(docBlocks).forEach(name => {
+      const docBlock = docBlocks[name];
+      it(name, () => {
+        expect(parseJsDoc(docBlock)).toMatchSnapshot();
       });
     });
   });
+  describe('@returns', () => {
+    const docBlocks = {
+      'extracts jsdoc types': '@returns {string}',
+      'extracts jsdoc mixed types': '@returns {*}',
+      'extracts description from jsdoc': '@returns The number',
+      'works with @return': '@return The number',
+      'extracts jsdoc typed array': '@param {[string, number]} bar',
+    };
 
-  describe('parameters', () => {
-    it('extracts jsdoc description', () => {
-      const docblock = `
-        @param bar test
-      `;
-      expect(parseJsDoc(docblock)).toEqual({
-        description: null,
-        returns: null,
-        params: [
-          {
-            name: 'bar',
-            type: null,
-            description: 'test',
-          },
-        ],
-      });
-    });
-
-    it('extracts jsdoc description', () => {
-      const docblock = `
-        @param {string} bar
-      `;
-      expect(parseJsDoc(docblock)).toEqual({
-        description: null,
-        returns: null,
-        params: [
-          {
-            name: 'bar',
-            type: { name: 'string' },
-            description: null,
-          },
-        ],
-      });
-    });
-
-    it('extracts jsdoc union type param', () => {
-      const docblock = `
-        @param {string|Object} bar
-      `;
-      expect(parseJsDoc(docblock)).toEqual({
-        description: null,
-        returns: null,
-        params: [
-          {
-            name: 'bar',
-            type: { name: 'union', value: ['string', 'Object'] },
-            description: null,
-          },
-        ],
-      });
-    });
-
-    it('extracts jsdoc optional', () => {
-      const docblock = `
-        @param {string=} bar
-      `;
-      expect(parseJsDoc(docblock)).toEqual({
-        description: null,
-        returns: null,
-        params: [
-          {
-            name: 'bar',
-            type: { name: 'string' },
-            description: null,
-            optional: true,
-          },
-        ],
-      });
-    });
-
-    describe('returns', () => {
-      it('returns null if return is not documented', () => {
-        const docblock = `
-          test
-        `;
-        expect(parseJsDoc(docblock)).toEqual({
-          description: 'test',
-          returns: null,
-          params: [],
-        });
-      });
-
-      it('extracts jsdoc types', () => {
-        const docblock = `
-          @returns {string}
-        `;
-        expect(parseJsDoc(docblock)).toEqual({
-          description: null,
-          returns: {
-            type: { name: 'string' },
-            description: null,
-          },
-          params: [],
-        });
-      });
-
-      it('extracts jsdoc mixed types', () => {
-        const docblock = `
-          @returns {*}
-        `;
-        expect(parseJsDoc(docblock)).toEqual({
-          description: null,
-          returns: {
-            type: { name: 'mixed' },
-            description: null,
-          },
-          params: [],
-        });
-      });
-
-      it('extracts description from jsdoc', () => {
-        const docblock = `
-          @returns The number
-        `;
-        expect(parseJsDoc(docblock)).toEqual({
-          description: null,
-          returns: {
-            type: null,
-            description: 'The number',
-          },
-          params: [],
-        });
-      });
-
-      it('works with @return', () => {
-        const docblock = `
-          @return The number
-        `;
-        expect(parseJsDoc(docblock)).toEqual({
-          description: null,
-          returns: {
-            type: null,
-            description: 'The number',
-          },
-          params: [],
-        });
+    Object.keys(docBlocks).forEach(name => {
+      const docBlock = docBlocks[name];
+      it(name, () => {
+        expect(parseJsDoc(docBlock)).toMatchSnapshot();
       });
     });
   });


### PR DESCRIPTION
BREAKING CHANGE: The type of method params and return is now aligned with
flow types.

fixes #285