### PR TITLE
Resolve flow $Keys to union when typeParameter is an ObjectTypeAnnotation

### DIFF
--- a/src/utils/__tests__/getFlowType-test.js
+++ b/src/utils/__tests__/getFlowType-test.js
@@ -535,6 +535,25 @@ describe('getFlowType', () => {
     });
   });
 
+  it('resolves $Keys with an ObjectTypeAnnotation typeParameter to union', () => {
+    const typePath = statement(`
+      var x: $Keys<{| apple: string, banana: string |}> = 2;
+    `)
+      .get('declarations', 0)
+      .get('id')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+
+    expect(getFlowType(typePath)).toEqual({
+      name: 'union',
+      elements: [
+        { name: 'literal', value: 'apple' },
+        { name: 'literal', value: 'banana' },
+      ],
+      raw: '$Keys<{| apple: string, banana: string |}>',
+    });
+  });
+
   it('handles multiple references to one type', () => {
     const typePath = statement(`
       let action: { a: Action, b: Action };

--- a/src/utils/__tests__/getFlowType-test.js
+++ b/src/utils/__tests__/getFlowType-test.js
@@ -512,6 +512,29 @@ describe('getFlowType', () => {
     });
   });
 
+  it('resolves $Keys without typeof to union', () => {
+    const typePath = statement(`
+      var x: $Keys<CONTENTS> = 2;
+      const CONTENTS = {
+        'apple': '🍎',
+        'banana': '🍌',
+      };
+    `)
+      .get('declarations', 0)
+      .get('id')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+
+    expect(getFlowType(typePath)).toEqual({
+      name: 'union',
+      elements: [
+        { name: 'literal', value: "'apple'" },
+        { name: 'literal', value: "'banana'" },
+      ],
+      raw: '$Keys<CONTENTS>',
+    });
+  });
+
   it('resolves $Keys with an ObjectTypeAnnotation typeParameter to union', () => {
     const typePath = statement(`
       var x: $Keys<{| apple: string, banana: string |}> = 2;

--- a/src/utils/__tests__/getFlowType-test.js
+++ b/src/utils/__tests__/getFlowType-test.js
@@ -512,29 +512,6 @@ describe('getFlowType', () => {
     });
   });
 
-  it('resolves $Keys without typeof to union', () => {
-    const typePath = statement(`
-      var x: $Keys<CONTENTS> = 2;
-      const CONTENTS = {
-        'apple': '🍎',
-        'banana': '🍌',
-      };
-    `)
-      .get('declarations', 0)
-      .get('id')
-      .get('typeAnnotation')
-      .get('typeAnnotation');
-
-    expect(getFlowType(typePath)).toEqual({
-      name: 'union',
-      elements: [
-        { name: 'literal', value: "'apple'" },
-        { name: 'literal', value: "'banana'" },
-      ],
-      raw: '$Keys<CONTENTS>',
-    });
-  });
-
   it('resolves $Keys with an ObjectTypeAnnotation typeParameter to union', () => {
     const typePath = statement(`
       var x: $Keys<{| apple: string, banana: string |}> = 2;
@@ -551,6 +528,27 @@ describe('getFlowType', () => {
         { name: 'literal', value: 'banana' },
       ],
       raw: '$Keys<{| apple: string, banana: string |}>',
+    });
+  });
+
+  it('resolves $Keys with an ObjectTypeAnnotation typeParameter to union with an ObjectTypeSpreadProperty', () => {
+    const typePath = statement(`
+      var x: $Keys<{| apple: string, banana: string, ...OtherFruits |}> = 2;
+      type OtherFruits = { orange: string }
+    `)
+      .get('declarations', 0)
+      .get('id')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+
+    expect(getFlowType(typePath)).toEqual({
+      name: 'union',
+      elements: [
+        { name: 'literal', value: 'apple' },
+        { name: 'literal', value: 'banana' },
+        { name: 'literal', value: 'orange' },
+      ],
+      raw: '$Keys<{| apple: string, banana: string, ...OtherFruits |}>',
     });
   });
 

--- a/src/utils/getFlowType.js
+++ b/src/utils/getFlowType.js
@@ -68,6 +68,8 @@ function handleKeysHelper(path: NodePath): ?FlowElementsType {
   let value = path.get('typeParameters', 'params', 0);
   if (types.TypeofTypeAnnotation.check(value.node)) {
     value = value.get('argument', 'id');
+  } else if (!types.ObjectTypeAnnotation.check(value.node)) {
+    value = value.get('id');
   }
   const resolvedPath = resolveToValue(value);
   if (

--- a/src/utils/getFlowType.js
+++ b/src/utils/getFlowType.js
@@ -90,9 +90,9 @@ function handleKeysHelper(path: NodePath): ?FlowElementsType {
     return {
       name: 'union',
       raw: printValue(path),
-      elements: resolvedPath.node.properties.map(prop => ({
+      elements: resolvedPath.get('properties').map(prop => ({
         name: 'literal',
-        value: prop.key.name,
+        value: getPropertyName(prop),
       })),
     };
   }

--- a/src/utils/getFlowType.js
+++ b/src/utils/getFlowType.js
@@ -68,7 +68,7 @@ function handleKeysHelper(path: NodePath): ?FlowElementsType {
   let value = path.get('typeParameters', 'params', 0);
   if (types.TypeofTypeAnnotation.check(value.node)) {
     value = value.get('argument', 'id');
-  } else {
+  } else if (!types.ObjectTypeAnnotation.check(value.node)) {
     value = value.get('id');
   }
   const resolvedPath = resolveToValue(value);
@@ -82,6 +82,19 @@ function handleKeysHelper(path: NodePath): ?FlowElementsType {
         elements: keys.map(key => ({ name: 'literal', value: key })),
       };
     }
+  } else if (
+    resolvedPath &&
+    types.ObjectTypeAnnotation.check(resolvedPath.node) &&
+    resolvedPath.node.properties.length
+  ) {
+    return {
+      name: 'union',
+      raw: printValue(path),
+      elements: resolvedPath.node.properties.map(prop => ({
+        name: 'literal',
+        value: prop.key.name,
+      })),
+    };
   }
 
   return null;


### PR DESCRIPTION
This adds support for ObjectTypeAnnotations as the typeParameter of $Keys.

This will now resolve to a union:

```
$Keys<{| a: string, b: string |}>
```
