### PR TITLE
Creates the component tag handler

### DIFF
--- a/src/handlers/componentTagHandler.js
+++ b/src/handlers/componentTagHandler.js
@@ -1,0 +1,18 @@
+/* @flow */
+import type Documentation from '../Documentation';
+
+export default function displayNameHandler(documentation: Documentation) {
+  const description = documentation.get('description');
+  const tagLines = description.split('\n').filter(line => line.includes('@'));
+
+  tagLines.forEach(tagLine => {
+    if (tagLine.includes(' ')) {
+      documentation.set(
+        tagLine.substring(1, tagLine.indexOf(' ')),
+        tagLine.substring(tagLine.indexOf(' ') + 1),
+      );
+    } else {
+      documentation.set(tagLine.substring(1), true);
+    }
+  });
+}


### PR DESCRIPTION
Hi! I've created a custom handler to add tags to Components.

The usage is simple, for example, a component with:
```
/**
* @beta
* @status new
* @subtitle This is a Button Component!
*/
class Button extends Component {
    ...
}
```

This should output:
```
{
    "displayName": "Button",
    "beta": true,
    "status": "new",
    "subtitle": "This is a Button Component!",
    ...
```

I needed this in my particular custom generated documentation! 

I can write tests and anything that is deemed necessary if you think this should be merged at all ;)