### PR TITLE
Allow descriptions for oneOfType values

### DIFF
--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -889,3 +889,47 @@ Object {
   },
 }
 `;
+
+exports[`main fixtures processes component "component_17.js" without errors 1`] = `
+Object {
+  "description": "",
+  "displayName": "Foo",
+  "methods": Array [],
+  "props": Object {
+    "oneOfTypeProp": Object {
+      "description": "",
+      "required": false,
+      "type": Object {
+        "name": "union",
+        "value": Array [
+          Object {
+            "description": "Comment for type string",
+            "name": "string",
+          },
+          Object {
+            "name": "number",
+          },
+        ],
+      },
+    },
+    "shapeProp": Object {
+      "description": "",
+      "required": false,
+      "type": Object {
+        "name": "shape",
+        "value": Object {
+          "a": Object {
+            "description": "Comment for property a",
+            "name": "string",
+            "required": false,
+          },
+          "b": Object {
+            "name": "number",
+            "required": false,
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/src/__tests__/fixtures/component_17.js
+++ b/src/__tests__/fixtures/component_17.js
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+/**
+ * Testing descriptions of shape and oneOfType values
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function Foo(props) {
+  return <div />;
+}
+
+Foo.propTypes = {
+  shapeProp: PropTypes.shape({
+    /** Comment for property a */
+    a: PropTypes.string,
+    b: PropTypes.number
+  }),
+  oneOfTypeProp: PropTypes.oneOfType([
+    /** Comment for type string */
+    PropTypes.string,
+    PropTypes.number
+  ])
+};

--- a/src/utils/getPropType.js
+++ b/src/utils/getPropType.js
@@ -80,7 +80,14 @@ function getPropTypeOneOfType(argumentPath) {
     type.computed = true;
     type.value = printValue(argumentPath);
   } else {
-    type.value = argumentPath.get('elements').map(getPropType);
+    type.value = argumentPath.get('elements').map(function(itemPath) {
+      const descriptor: PropTypeDescriptor = getPropType(itemPath);
+      const docs = getDocblock(itemPath);
+      if (docs) {
+        descriptor.description = docs;
+      }
+      return descriptor;
+    });
   }
   return type;
 }


### PR DESCRIPTION
Hey!

Hope you don't mind me putting this PR together without a clear consent for this feature. I just had a lot of fun diving into this 😄 

### Changes
Allows values of `oneOfType` to have descriptions as well, similar to properties of `shape`. Fixes #300.

### Example

```js
{
  foo: PropTypes.shape({
    /** This was possible previously */
    a: PropTypes.string
  }),
  bar: PropTypes.oneOfType([
    /** Now this is possible, too */
    PropTypes.string,
    PropTypes.number
  ])
}
```