### PR TITLE
fix: Ignore assignment to non-identifier/literals

### DIFF
--- a/src/handlers/__tests__/displayNameHandler-test.js
+++ b/src/handlers/__tests__/displayNameHandler-test.js
@@ -223,5 +223,14 @@ describe('defaultPropsHandler', () => {
       expect(() => displayNameHandler(documentation, definition)).not.toThrow();
       expect(documentation.displayName).toBe('Bar');
     });
+
+    it('ignores assignment to non-literal/identifier', () => {
+      const definition = statement('Foo.Bar = () => {};').get(
+        'expression',
+        'right',
+      );
+      expect(() => displayNameHandler(documentation, definition)).not.toThrow();
+      expect(documentation.displayName).not.toBeDefined();
+    });
   });
 });

--- a/src/handlers/displayNameHandler.js
+++ b/src/handlers/displayNameHandler.js
@@ -48,11 +48,14 @@ export default function displayNameHandler(
           );
           return;
         } else if (types.AssignmentExpression.check(currentPath.parent.node)) {
-          documentation.set(
-            'displayName',
-            getNameOrValue(currentPath.parent.get('left')),
-          );
-          return;
+          const leftPath = currentPath.parent.get('left');
+          if (
+            types.Identifier.check(leftPath.node) ||
+            types.Literal.check(leftPath.node)
+          ) {
+            documentation.set('displayName', getNameOrValue(leftPath));
+            return;
+          }
         }
         currentPath = currentPath.parent;
       }


### PR DESCRIPTION
Currently, `react-docgen` fatals on components assigned to non-identifier/literals. For example:

```
Foo.Bar = () => {};
// TypeError: Argument must be an Identifier or a Literal
```

This fixes it by checking the left expression of the assignment before attempting to extract its name.

**Test Plan:**

```
yarn test
yarn flow
yarn lint
```