### PR TITLE
Add forwardRef as a valid component definition

### DIFF
--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -933,3 +933,33 @@ Object {
   },
 }
 `;
+
+exports[`main fixtures processes component "component_18.js" without errors 1`] = `
+Object {
+  "description": "",
+  "displayName": "UncoloredView",
+  "methods": Array [],
+  "props": Object {
+    "color": Object {
+      "description": "",
+      "required": false,
+      "type": Object {
+        "name": "custom",
+        "raw": "PropTypes.string.isRequired",
+      },
+    },
+    "id": Object {
+      "defaultValue": Object {
+        "computed": false,
+        "value": "'test-forward-ref-default'",
+      },
+      "description": "",
+      "required": false,
+      "type": Object {
+        "name": "custom",
+        "raw": "PropTypes.string",
+      },
+    },
+  },
+}
+`;

--- a/src/__tests__/fixtures/component_18.js
+++ b/src/__tests__/fixtures/component_18.js
@@ -1,0 +1,15 @@
+
+import React from 'react';
+import extendStyles from 'enhancers/extendStyles';
+
+type Props = $ReadOnly<{|
+  color?: ?string,
+|}>;
+
+const ColoredView = React.forwardRef((props: Props, ref) => (
+  <View style={{backgroundColor: props.color}} />
+));
+
+ColoredView.displayName = 'UncoloredView';
+
+module.exports = extendStyles(ColoredView);

--- a/src/__tests__/fixtures/component_18.js
+++ b/src/__tests__/fixtures/component_18.js
@@ -7,9 +7,16 @@ type Props = $ReadOnly<{|
 |}>;
 
 const ColoredView = React.forwardRef((props: Props, ref) => (
-  <View style={{backgroundColor: props.color}} />
+  <div ref={ref} style={{backgroundColor: props.color}} />
 ));
 
 ColoredView.displayName = 'UncoloredView';
+ColoredView.propTypes = {
+  color: PropTypes.string.isRequired,
+  id: PropTypes.string
+}
+ColoredView.defaultProps = {
+  id: 'test-forward-ref-default'
+}
 
 module.exports = extendStyles(ColoredView);

--- a/src/resolver/findExportedComponentDefinition.js
+++ b/src/resolver/findExportedComponentDefinition.js
@@ -10,6 +10,7 @@
  */
 
 import isExportsOrModuleAssignment from '../utils/isExportsOrModuleAssignment';
+import isReactForwardRefCall from '../utils/isReactForwardRefCall';
 import isReactComponentClass from '../utils/isReactComponentClass';
 import isReactCreateClassCall from '../utils/isReactCreateClassCall';
 import isStatelessComponent from '../utils/isStatelessComponent';
@@ -29,7 +30,8 @@ function isComponentDefinition(path) {
   return (
     isReactCreateClassCall(path) ||
     isReactComponentClass(path) ||
-    isStatelessComponent(path)
+    isStatelessComponent(path) ||
+    isReactForwardRefCall(path)
   );
 }
 
@@ -44,6 +46,8 @@ function resolveDefinition(definition, types) {
     normalizeClassDefinition(definition);
     return definition;
   } else if (isStatelessComponent(definition)) {
+    return definition;
+  } else if (isReactForwardRefCall(definition)) {
     return definition;
   }
   return null;

--- a/src/utils/getMemberExpressionValuePath.js
+++ b/src/utils/getMemberExpressionValuePath.js
@@ -12,6 +12,7 @@
 
 import getNameOrValue from './getNameOrValue';
 import { String as toString } from './expressionTo';
+import isReactForwardRefCall from './isReactForwardRefCall';
 import recast from 'recast';
 
 const {
@@ -40,7 +41,8 @@ function resolveName(path) {
   if (
     types.FunctionExpression.check(path.node) ||
     types.ArrowFunctionExpression.check(path.node) ||
-    types.TaggedTemplateExpression.check(path.node)
+    types.TaggedTemplateExpression.check(path.node) ||
+    isReactForwardRefCall(path)
   ) {
     let currentPath = path;
     while (currentPath.parent) {
@@ -56,7 +58,7 @@ function resolveName(path) {
 
   throw new TypeError(
     'Attempted to resolveName for an unsupported path. resolveName accepts a ' +
-      'VariableDeclaration, FunctionDeclaration, or FunctionExpression. Got "' +
+      'VariableDeclaration, FunctionDeclaration, FunctionExpression or CallExpression. Got "' +
       path.node.type +
       '".',
   );

--- a/src/utils/getMemberValuePath.js
+++ b/src/utils/getMemberValuePath.js
@@ -34,6 +34,7 @@ const POSTPROCESS_MEMBERS = {
 
 const LOOKUP_METHOD = {
   [types.ArrowFunctionExpression.name]: getMemberExpressionValuePath,
+  [types.CallExpression.name]: getMemberExpressionValuePath,
   [types.FunctionExpression.name]: getMemberExpressionValuePath,
   [types.FunctionDeclaration.name]: getMemberExpressionValuePath,
   [types.VariableDeclaration.name]: getMemberExpressionValuePath,
@@ -62,7 +63,8 @@ function isSupportedDefinitionType({ node }) {
     types.VariableDeclaration.check(node) ||
     types.ArrowFunctionExpression.check(node) ||
     types.FunctionDeclaration.check(node) ||
-    types.FunctionExpression.check(node)
+    types.FunctionExpression.check(node) ||
+    types.CallExpression.check(node)
   );
 }
 
@@ -88,7 +90,7 @@ export default function getMemberValuePath(
       'Got unsupported definition type. Definition must be one of ' +
         'ObjectExpression, ClassDeclaration, ClassExpression,' +
         'VariableDeclaration, ArrowFunctionExpression, FunctionExpression, ' +
-        'TaggedTemplateExpression or FunctionDeclaration. Got "' +
+        'TaggedTemplateExpression, FunctionDeclaration or CallExpression. Got "' +
         componentDefinition.node.type +
         '"' +
         'instead.',

--- a/src/utils/isReactForwardRefCall.js
+++ b/src/utils/isReactForwardRefCall.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+import isReactModuleName from './isReactModuleName';
+import match from './match';
+import recast from 'recast';
+import resolveToModule from './resolveToModule';
+
+const {
+  types: { namedTypes: types },
+} = recast;
+
+/**
+ * Returns true if the expression is a function call of the form
+ * `React.forwardRef(...)`.
+ */
+export default function isReactForwardRefCall(path: NodePath): boolean {
+  if (types.ExpressionStatement.check(path.node)) {
+    path = path.get('expression');
+  }
+
+  if (!match(path.node, { callee: { property: { name: 'forwardRef' } } })) {
+    return false;
+  }
+  const module = resolveToModule(path.get('callee', 'object'));
+  return Boolean(module && isReactModuleName(module));
+}


### PR DESCRIPTION
- recognizes `React.forwardRef` as a valid component in a hoc
- adds support for `propTypes` and `defaultProps` for `React.forwardRef` components

Started out as a simple fix to recognize `export default hoc(React.forwardRef(...))` until I realized that `forwardRef` is not supported in `propTypes` handler.

I can split those two up if you want to (moving propTypes to fixture 14 and simply using 18 as the hoc+forwardRef fixture). As far as I understood the codebase this needs to be ported to every resolver? I haven't used flow in over a year so everything flow related (as most of the other additions) is just copy and paste.