### PR TITLE
Support custom parser options in programmatic API

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -9,3 +9,5 @@ src/
 [libs]
 
 [options]
+
+suppress_comment= \\(.\\|\n\\)*\\$FlowIssue

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Options:
    -i, --ignore          Folders to ignore. Default:  [node_modules,__tests__,__mocks__]
    --resolver RESOLVER   Resolver name (findAllComponentDefinitions, findExportedComponentDefinition) or
       path to a module that exports a resolver.  [findExportedComponentDefinition]
-   --legacy-decorators   Switch parsing to support only the legacy decorators syntax
 
 Extract meta information from React components.
 If a directory is passed, it is recursively traversed.
@@ -59,6 +58,9 @@ resolvers](#resolver).
 
 Have a look at `example/` for an example of how to use the result to generate a
 markdown version of the documentation.
+
+`react-docgen` will look for a babel configuration and use it if available. If no config file is found
+it will fallback to a default configuration, enabling all [syntax extension](https://babeljs.io/docs/en/babel-parser#plugins) of the babel-parser.
 
 ## API
 
@@ -83,7 +85,31 @@ As with the CLI, this will look for the exported component created through `Reac
 | source       | string | The source text |
 | resolver     | function | A function of the form `(ast: ASTNode, recast: Object) => (NodePath|Array<NodePath>)`. Given an AST and a reference to recast, it returns an (array of) NodePath which represents the component definition. |
 | handlers     | Array\<function\> | An array of functions of the form `(documentation: Documentation, definition: NodePath) => void`. Each function is called with a `Documentation` object and a reference to the component definition as returned by `resolver`. Handlers extract relevant information from the definition and augment `documentation`. |
-| options      | Object | Pass options to react-docgen. Supported option is `legacyDecorators` which is a boolean |
+| options      | Object | Pass options to react-docgen, see below. |
+
+#### options
+
+##### ∙ filename
+
+Type: `string`
+
+The absolute path to the file associated with the code currently being parsed, if there is one. This is used to search for the correct babel config.
+
+This option is optional, but it is highly recommended to set it when integrating `react-docgen`.
+
+##### ∙ cwd
+
+Type: `string`
+Default: `process.cwd()`
+
+The working directory that babel configurations will be searched in.
+
+##### ∙ parserOptions
+
+Type: `BabelParserOptions`
+
+This options will be directly supplied to `@babel/parser`. To see a list of
+supported options head over to the [babel website](https://babeljs.io/docs/en/babel-parser#options) and have a look.
 
 #### resolver
 

--- a/bin/react-docgen.js
+++ b/bin/react-docgen.js
@@ -42,14 +42,6 @@ argv
     []
   )
   .option(
-    '--legacy-decorators',
-    'Enable parsing of legacy decorators proposal. By default only the new decorators syntax will be parsable.'
-  )
-  .option(
-    '--decorators-before-export',
-    'Switches the decorators proposal to allow decorators before the export statement. By default this is false.'
-  )
-  .option(
     '-i, --ignore <path>',
     'Folders to ignore. Default: ' + JSON.stringify(defaultIgnore),
     collect,
@@ -115,8 +107,6 @@ if (argv.resolver) {
 function parse(source, filename) {
   return parser.parse(source, resolver, null, {
     filename,
-    legacyDecorators: argv.legacyDecorators,
-    decoratorsBeforeExport: argv.decoratorsBeforeExport,
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "eslint": "^5.7.0",
     "eslint-config-prettier": "^3.1.0",
     "eslint-plugin-prettier": "^3.0.0",
-    "flow-bin": "^0.87.0",
+    "flow-bin": "^0.93.0",
     "jest": "^23.6.0",
     "jest-diff": "^23.6.0",
     "jest-matcher-utils": "^23.6.0",

--- a/src/__tests__/parse-test.js
+++ b/src/__tests__/parse-test.js
@@ -52,7 +52,7 @@ describe('parse', () => {
     expect(resolver).toBeCalled();
   });
 
-  it.only('uses local babelrc', () => {
+  it('uses local babelrc', () => {
     const dir = temp.mkdirSync();
 
     try {
@@ -71,5 +71,18 @@ describe('parse', () => {
       fs.unlinkSync(`${dir}/.babelrc`);
       fs.rmdirSync(dir);
     }
+  });
+
+  it('supports custom parserOptions', () => {
+    expect(() =>
+      parse('const chained: Type = 1;', () => {}, null, {
+        parserOptions: {
+          plugins: [
+            // no flow
+            'jsx',
+          ],
+        },
+      }),
+    ).toThrowError(/.*Unexpected token \(1:13\).*/);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1984,10 +1984,10 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.87.0:
-  version "0.87.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.87.0.tgz#fab7f984d8cc767e93fa9eb01cf7d57ed744f19d"
-  integrity sha512-mnvBXXZkUp4y6A96bR5BHa3q1ioIIN2L10w5osxJqagAakTXFYZwjl0t9cT3y2aCEf1wnK6n91xgYypQS/Dqbw==
+flow-bin@^0.93.0:
+  version "0.93.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.93.0.tgz#9192a08d88db2a8da0ff55e42420f44539791430"
+  integrity sha512-p8yq4ocOlpyJgOEBEj0v0GzCP25c9WP0ilFQ8hXSbrTR7RPKuR+Whr+OitlVyp8ocdX0j1MrIwQ8x28dacy1pg==
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Add `logicalAssignment` to the default plugins.

BREAKING CHANGE: Removed cli arguments `--legacy-decorators` and `--decorators-before-export`. Instead use a babel configuration file with the correct options for the transforms.
BREAKING CHANGE: Removed api options `legacyDecorators` and `decoratorsBeforeExport`. Instead use a babel configuration file or supply `parserOptions` and enable the plugins with the correct options.

Do you think this is okay and works with your usecases? I wanted to add this before doing 4.0.

So basically the options are now:

1. No config file and no parserOptions => defaultPlugins
2. No config file and parserOptions with plugins => parserOptions only
3. No config file and parserOptions without plugins => parserOptions + defaultPlugins
4. Config File and no parserOptions => config file only
5. Config File and parserOptions with plugins => babel merges config file with parserOptions
6. Config File and parserOptions without plugins => babel merges config file with parserOptions and defaultPlugins

In all 6 cases `estree` plugin is now added and `tokens` set to true, as both are required.