### PR TITLE
feat: support PropTypes.elementType

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -28,7 +28,8 @@ export type PropTypeDescriptor = {
     | 'objectOf'
     | 'shape'
     | 'exact'
-    | 'union',
+    | 'union'
+    | 'elementType',
   value?: any,
   raw?: string,
   computed?: boolean,

--- a/src/utils/__tests__/getPropType-test.js
+++ b/src/utils/__tests__/getPropType-test.js
@@ -33,6 +33,7 @@ describe('getPropType', () => {
       'element',
       'node',
       'symbol',
+      'elementType',
     ];
 
     simplePropTypes.forEach(type =>

--- a/src/utils/getPropType.js
+++ b/src/utils/getPropType.js
@@ -188,6 +188,7 @@ const simplePropTypes = [
   'element',
   'node',
   'symbol',
+  'elementType',
 ];
 
 const propTypes = {


### PR DESCRIPTION
Introduced in facebook/prop-types#211, released in [`prop-types@15.7.0`](https://github.com/facebook/prop-types/blob/v15.7.0/CHANGELOG.md#1570).