### PR TITLE
[flow] Ignore spread properties in object type

### DIFF
--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -1001,3 +1001,68 @@ Object {
   },
 }
 `;
+
+exports[`main fixtures processes component "component_19.js" without errors 1`] = `
+Object {
+  "composes": Array [
+    undefined,
+  ],
+  "description": "",
+  "displayName": "Component",
+  "methods": Array [
+    Object {
+      "docblock": null,
+      "modifiers": Array [],
+      "name": "UNSAFE_componentWillReceiveProps",
+      "params": Array [
+        Object {
+          "name": "nextProps",
+          "optional": undefined,
+          "type": Object {
+            "alias": "Props",
+            "name": "signature",
+            "raw": "{|
+  data?: Array<mixed>,
+  ...React.ElementConfig<typeof SomeOtherComponent>,
+|}",
+            "signature": Object {
+              "properties": Array [
+                Object {
+                  "key": "data",
+                  "value": Object {
+                    "elements": Array [
+                      Object {
+                        "name": "mixed",
+                      },
+                    ],
+                    "name": "Array",
+                    "raw": "Array<mixed>",
+                    "required": false,
+                  },
+                },
+              ],
+            },
+            "type": "object",
+          },
+        },
+      ],
+      "returns": null,
+    },
+  ],
+  "props": Object {
+    "data": Object {
+      "description": "",
+      "flowType": Object {
+        "elements": Array [
+          Object {
+            "name": "mixed",
+          },
+        ],
+        "name": "Array",
+        "raw": "Array<mixed>",
+      },
+      "required": false,
+    },
+  },
+}
+`;

--- a/src/__tests__/fixtures/component_19.js
+++ b/src/__tests__/fixtures/component_19.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+type Props = {|
+  data?: Array<mixed>,
+  ...React.ElementConfig<typeof SomeOtherComponent>,
+|};
+
+type State = {|
+  width: number,
+|};
+
+export default class Component extends React.PureComponent<Props, State> {
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
+    doSomething();
+  }
+
+  render() {
+    return (
+      <div>Hello</div>
+    );
+  }
+}

--- a/src/utils/getFlowType.js
+++ b/src/utils/getFlowType.js
@@ -161,10 +161,12 @@ function handleObjectTypeAnnotation(path: NodePath): FlowTypeDescriptor {
   });
 
   path.get('properties').each(param => {
-    type.signature.properties.push({
-      key: getPropertyName(param),
-      value: getFlowTypeWithRequirements(param.get('value')),
-    });
+    if (types.ObjectTypeProperty.check(param.node)) {
+      type.signature.properties.push({
+        key: getPropertyName(param),
+        value: getFlowTypeWithRequirements(param.get('value')),
+      });
+    }
   });
 
   return type;


### PR DESCRIPTION
The new fixtures shows an example that currently fails with the error

```
TypeError: Argument must be an Identifier or a Literal
    at getNameOrValue (/home/fkling/git/react-docgen/dist/utils/getNameOrValue.js:40:13)
    at getPropertyName (/home/fkling/git/react-docgen/dist/utils/getPropertyName.js:34:40)
    at NodePath.path.get.each.param (/home/fkling/git/react-docgen/dist/utils/getFlowType.js:171:41)
    at NodePath.each (/home/fkling/git/react-docgen/node_modules/ast-types/lib/path.js:89:26)
    at Object.handleObjectTypeAnnotation [as ObjectTypeAnnotation] (/home/fkling/git/react-docgen/dist/utils/getFlowType.js:168:26)
    at getFlowTypeWithResolvedTypes (/home/fkling/git/react-docgen/dist/utils/getFlowType.js:274:35)
    at Object.handleGenericTypeAnnotation [as GenericTypeAnnotation] (/home/fkling/git/react-docgen/dist/utils/getFlowType.js:143:14)
    at getFlowTypeWithResolvedTypes (/home/fkling/git/react-docgen/dist/utils/getFlowType.js:274:35)
    at getFlowType (/home/fkling/git/react-docgen/dist/utils/getFlowType.js:305:16)
    at NodePath.functionExpression.get.each.paramPath (/home/fkling/git/react-docgen/dist/utils/getMethodDocumentation.js:43:39)
```

That's because the method is referencing the `Props` type, but is not setup to
deal with spread properties (like the flowTypeHandler) is.

This change updates the code to ignore anything that is not a property.

We could also change this to resolve spread properties locally and merge them, like the handler does, but I wasn't quite sure how to do that (the handler seems to work quite differently).