### PR TITLE
Handle computed properties correctly and do not fail generation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,5 +27,9 @@ module.exports = {
         'no-unused-vars': 'off',
       },
     },
+    {
+      files: 'src/**/__tests__/*-test.js',
+      env: { jest: true },
+    },
   ],
 };

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -1027,3 +1027,24 @@ Object {
   },
 }
 `;
+
+exports[`main fixtures processes component "component_20.js" without errors 1`] = `
+Object {
+  "description": "",
+  "displayName": "Button",
+  "methods": Array [],
+  "props": Object {
+    "@computed#children": Object {
+      "defaultValue": Object {
+        "computed": false,
+        "value": "\\"default\\"",
+      },
+      "description": "This is a test",
+      "required": false,
+      "type": Object {
+        "name": "string",
+      },
+    },
+  },
+}
+`;

--- a/src/__tests__/fixtures/component_20.js
+++ b/src/__tests__/fixtures/component_20.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Button = () => (
+  <div></div>
+);
+
+Button.propTypes = {
+  /** This is a test */
+  [children]: PropTypes.string.isRequired,
+};
+
+Button.defaultProps = {
+  [children]: "default",
+};
+
+export default Button;

--- a/src/handlers/__tests__/__snapshots__/componentMethodsHandler-test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/componentMethodsHandler-test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`componentMethodsHandler should handle and ignore computed methods 1`] = `
+Array [
+  Object {
+    "docblock": "The foo method",
+    "modifiers": Array [],
+    "name": "@computed#foo",
+    "params": Array [
+      Object {
+        "name": "bar",
+        "optional": undefined,
+        "type": Object {
+          "name": "number",
+        },
+      },
+    ],
+    "returns": Object {
+      "type": Object {
+        "name": "number",
+      },
+    },
+  },
+]
+`;

--- a/src/handlers/__tests__/__snapshots__/defaultPropsHandler-test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/defaultPropsHandler-test.js.snap
@@ -1,0 +1,238 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`defaultPropsHandler ClassDeclaration with static defaultProps should find prop default values that are imported variables 1`] = `
+Object {
+  "foo": Object {
+    "defaultValue": Object {
+      "computed": true,
+      "value": "ImportedComponent",
+    },
+  },
+}
+`;
+
+exports[`defaultPropsHandler ClassDeclaration with static defaultProps should find prop default values that are literals 1`] = `
+Object {
+  "abc": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "{xyz: abc.def, 123: 42}",
+    },
+  },
+  "bar": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "42",
+    },
+  },
+  "baz": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "[\\"foo\\", \\"bar\\"]",
+    },
+  },
+  "foo": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "\\"bar\\"",
+    },
+  },
+}
+`;
+
+exports[`defaultPropsHandler ClassExpression with static defaultProps should find prop default values that are literals 1`] = `
+Object {
+  "abc": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "{xyz: abc.def, 123: 42}",
+    },
+  },
+  "bar": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "42",
+    },
+  },
+  "baz": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "[\\"foo\\", \\"bar\\"]",
+    },
+  },
+  "foo": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "\\"bar\\"",
+    },
+  },
+}
+`;
+
+exports[`defaultPropsHandler Functional components with default params should find default props that are literals 1`] = `
+Object {
+  "abc": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "{xyz: abc.def, 123: 42}",
+    },
+  },
+  "bar": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "42",
+    },
+  },
+  "baz": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "[\\"foo\\", \\"bar\\"]",
+    },
+  },
+  "foo": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "\\"bar\\"",
+    },
+  },
+}
+`;
+
+exports[`defaultPropsHandler Functional components with default params should find prop default values that are imported variables 1`] = `
+Object {
+  "foo": Object {
+    "defaultValue": Object {
+      "computed": true,
+      "value": "ImportedComponent",
+    },
+  },
+}
+`;
+
+exports[`defaultPropsHandler Functional components with default params should override with defaultProps if available 1`] = `
+Object {
+  "abc": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "{xyz: abc.def, 123: 42}",
+    },
+  },
+  "bar": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "42",
+    },
+  },
+  "baz": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "[\\"foo\\", \\"bar\\"]",
+    },
+  },
+  "foo": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "\\"bar\\"",
+    },
+  },
+}
+`;
+
+exports[`defaultPropsHandler Functional components with default params should work with aliases 1`] = `
+Object {
+  "abc": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "{xyz: abc.def, 123: 42}",
+    },
+  },
+  "bar": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "42",
+    },
+  },
+  "baz": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "[\\"foo\\", \\"bar\\"]",
+    },
+  },
+  "foo": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "\\"bar\\"",
+    },
+  },
+}
+`;
+
+exports[`defaultPropsHandler Functional components with default params should work with no defaults 1`] = `Object {}`;
+
+exports[`defaultPropsHandler ObjectExpression handles computed properties 1`] = `
+Object {
+  "@computed#bar": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "42",
+    },
+  },
+  "foo": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "\\"bar\\"",
+    },
+  },
+}
+`;
+
+exports[`defaultPropsHandler ObjectExpression ignores complex computed properties 1`] = `
+Object {
+  "foo": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "\\"bar\\"",
+    },
+  },
+}
+`;
+
+exports[`defaultPropsHandler ObjectExpression should find prop default values that are literals 1`] = `
+Object {
+  "abc": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "{xyz: abc.def, 123: 42}",
+    },
+  },
+  "bar": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "42",
+    },
+  },
+  "baz": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "[\\"foo\\", \\"bar\\"]",
+    },
+  },
+  "foo": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "\\"bar\\"",
+    },
+  },
+}
+`;
+
+exports[`defaultPropsHandler should only consider Property nodes, not e.g. spread properties 1`] = `
+Object {
+  "bar": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "42",
+    },
+  },
+}
+`;

--- a/src/handlers/__tests__/__snapshots__/flowTypeHandler-test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/flowTypeHandler-test.js.snap
@@ -1,5 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`flowTypeHandler TypeAlias class definition for flow <0.53 ignores hash map entry 1`] = `
+Object {
+  "bar": Object {
+    "description": "",
+    "flowType": Object {},
+    "required": false,
+  },
+}
+`;
+
+exports[`flowTypeHandler TypeAlias class definition for flow >=0.53 with State ignores hash map entry 1`] = `
+Object {
+  "bar": Object {
+    "description": "",
+    "flowType": Object {},
+    "required": false,
+  },
+}
+`;
+
+exports[`flowTypeHandler TypeAlias class definition for flow >=0.53 without State ignores hash map entry 1`] = `
+Object {
+  "bar": Object {
+    "description": "",
+    "flowType": Object {},
+    "required": false,
+  },
+}
+`;
+
+exports[`flowTypeHandler TypeAlias class definition with inline props ignores hash map entry 1`] = `
+Object {
+  "bar": Object {
+    "description": "",
+    "flowType": Object {},
+    "required": false,
+  },
+}
+`;
+
+exports[`flowTypeHandler TypeAlias stateless component ignores hash map entry 1`] = `
+Object {
+  "bar": Object {
+    "description": "",
+    "flowType": Object {},
+    "required": false,
+  },
+}
+`;
+
 exports[`flowTypeHandler does support utility types inline 1`] = `
 Object {
   "foo": Object {

--- a/src/handlers/__tests__/__snapshots__/propTypeHandler-test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/propTypeHandler-test.js.snap
@@ -1,0 +1,89 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`propTypeHandler React.createClass handles computed properties 1`] = `
+Object {
+  "@computed#foo": Object {
+    "required": true,
+    "type": Object {},
+  },
+  "complex_prop": Object {
+    "required": true,
+    "type": Object {},
+  },
+}
+`;
+
+exports[`propTypeHandler React.createClass ignores complex computed properties 1`] = `
+Object {
+  "complex_prop": Object {
+    "required": true,
+    "type": Object {},
+  },
+}
+`;
+
+exports[`propTypeHandler class definition class property handles computed properties 1`] = `
+Object {
+  "@computed#foo": Object {
+    "required": true,
+    "type": Object {},
+  },
+  "complex_prop": Object {
+    "required": true,
+    "type": Object {},
+  },
+}
+`;
+
+exports[`propTypeHandler class definition class property ignores complex computed properties 1`] = `
+Object {
+  "complex_prop": Object {
+    "required": true,
+    "type": Object {},
+  },
+}
+`;
+
+exports[`propTypeHandler class definition static getter handles computed properties 1`] = `
+Object {
+  "@computed#foo": Object {
+    "required": true,
+    "type": Object {},
+  },
+  "complex_prop": Object {
+    "required": true,
+    "type": Object {},
+  },
+}
+`;
+
+exports[`propTypeHandler class definition static getter ignores complex computed properties 1`] = `
+Object {
+  "complex_prop": Object {
+    "required": true,
+    "type": Object {},
+  },
+}
+`;
+
+exports[`propTypeHandler stateless component handles computed properties 1`] = `
+Object {
+  "@computed#foo": Object {
+    "required": true,
+    "type": Object {},
+  },
+  "complex_prop": Object {
+    "required": true,
+    "type": Object {},
+  },
+}
+`;
+
+exports[`propTypeHandler stateless component ignores complex computed properties 1`] = `
+Object {
+  "complex_prop": Object {
+    "required": true,
+    "type": Object {},
+  },
+}
+`;

--- a/src/handlers/__tests__/componentMethodsHandler-test.js
+++ b/src/handlers/__tests__/componentMethodsHandler-test.js
@@ -130,6 +130,35 @@ describe('componentMethodsHandler', () => {
     test(parse(src).get('body', 0));
   });
 
+  it('should handle and ignore computed methods', () => {
+    const src = `
+      class Test {
+        /**
+         * The foo method
+         */
+        [foo](bar: number): number {
+          return bar;
+        }
+
+        /**
+         * Should not show up
+         */
+        [() => {}](bar: number): number {
+          return bar;
+        }
+
+        componentDidMount() {}
+
+        render() {
+          return null;
+        }
+      }
+    `;
+
+    componentMethodsHandler(documentation, parse(src).get('body', 0));
+    expect(documentation.methods).toMatchSnapshot();
+  });
+
   it('should not find methods for stateless components', () => {
     const src = `
       (props) => {}

--- a/src/handlers/__tests__/flowTypeHandler-test.js
+++ b/src/handlers/__tests__/flowTypeHandler-test.js
@@ -94,6 +94,20 @@ describe('flowTypeHandler', () => {
       });
     });
 
+    it('ignores hash map entry', () => {
+      const flowTypesSrc = `
+      {
+        [key: string]: string,
+        bar?: number,
+      }
+      `;
+      const definition = getSrc(flowTypesSrc);
+
+      flowTypeHandler(documentation, definition);
+
+      expect(documentation.descriptors).toMatchSnapshot();
+    });
+
     it('detects union types', () => {
       const flowTypesSrc = `
       {

--- a/src/handlers/__tests__/propTypeHandler-test.js
+++ b/src/handlers/__tests__/propTypeHandler-test.js
@@ -6,8 +6,6 @@
  *
  */
 
-/*global jest, describe, it, expect, beforeEach*/
-
 jest.mock('../../Documentation');
 jest.mock('../../utils/getPropType', () => jest.fn(() => ({})));
 
@@ -119,6 +117,36 @@ describe('propTypeHandler', () => {
           required: true,
         },
       });
+    });
+
+    it('handles computed properties', () => {
+      const definition = parse(
+        getSrc(
+          `{
+          [foo]: PropTypes.array.isRequired,
+          complex_prop:
+            PropTypes.oneOfType([PropTypes.number, PropTypes.bool]).isRequired,
+        }`,
+        ),
+      );
+
+      propTypeHandler(documentation, definition);
+      expect(documentation.descriptors).toMatchSnapshot();
+    });
+
+    it('ignores complex computed properties', () => {
+      const definition = parse(
+        getSrc(
+          `{
+          [() => {}]: PropTypes.array.isRequired,
+          complex_prop:
+            PropTypes.oneOfType([PropTypes.number, PropTypes.bool]).isRequired,
+        }`,
+        ),
+      );
+
+      propTypeHandler(documentation, definition);
+      expect(documentation.descriptors).toMatchSnapshot();
     });
 
     it('only considers definitions from React or ReactPropTypes', () => {

--- a/src/handlers/componentMethodsHandler.js
+++ b/src/handlers/componentMethodsHandler.js
@@ -67,5 +67,8 @@ export default function componentMethodsHandler(
     }
   }
 
-  documentation.set('methods', methodPaths.map(getMethodDocumentation));
+  documentation.set(
+    'methods',
+    methodPaths.map(getMethodDocumentation).filter(Boolean),
+  );
 }

--- a/src/handlers/defaultPropsHandler.js
+++ b/src/handlers/defaultPropsHandler.js
@@ -96,10 +96,11 @@ function getDefaultValuesFromProps(
         !isStateless ||
         types.AssignmentPattern.check(propertyPath.get('value').node),
     )
-    .forEach(function(propertyPath) {
-      const propDescriptor = documentation.getPropDescriptor(
-        getPropertyName(propertyPath),
-      );
+    .forEach(propertyPath => {
+      const propName = getPropertyName(propertyPath);
+      if (!propName) return;
+
+      const propDescriptor = documentation.getPropDescriptor(propName);
       const defaultValue = getDefaultValue(
         isStateless
           ? propertyPath.get('value', 'right')

--- a/src/handlers/flowTypeHandler.js
+++ b/src/handlers/flowTypeHandler.js
@@ -46,9 +46,10 @@ function setPropDescriptor(documentation: Documentation, path: NodePath): void {
     }
   } else if (types.ObjectTypeProperty.check(path.node)) {
     const type = getFlowType(path.get('value'));
-    const propDescriptor = documentation.getPropDescriptor(
-      getPropertyName(path),
-    );
+    const propName = getPropertyName(path);
+    if (!propName) return;
+
+    const propDescriptor = documentation.getPropDescriptor(propName);
     propDescriptor.required = !path.node.optional;
     propDescriptor.flowType = type;
 

--- a/src/handlers/propTypeHandler.js
+++ b/src/handlers/propTypeHandler.js
@@ -36,10 +36,13 @@ function amendPropTypes(getDescriptor, path) {
     return;
   }
 
-  path.get('properties').each(function(propertyPath) {
+  path.get('properties').each(propertyPath => {
     switch (propertyPath.node.type) {
       case types.Property.name: {
-        const propDescriptor = getDescriptor(getPropertyName(propertyPath));
+        const propName = getPropertyName(propertyPath);
+        if (!propName) return;
+
+        const propDescriptor = getDescriptor(propName);
         const valuePath = propertyPath.get('value');
         const type = isPropTypesExpression(valuePath)
           ? getPropType(valuePath)

--- a/src/utils/__tests__/__snapshots__/getMethodDocumentation-test.js.snap
+++ b/src/utils/__tests__/__snapshots__/getMethodDocumentation-test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getMethodDocumentation name handles computed method name 1`] = `
+Object {
+  "docblock": null,
+  "modifiers": Array [],
+  "name": "@computed#foo",
+  "params": Array [],
+  "returns": null,
+}
+`;
+
+exports[`getMethodDocumentation name ignores complex computed method name 1`] = `null`;

--- a/src/utils/__tests__/__snapshots__/getPropType-test.js.snap
+++ b/src/utils/__tests__/__snapshots__/getPropType-test.js.snap
@@ -102,6 +102,34 @@ Object {
 }
 `;
 
+exports[`getPropType handles computed properties 1`] = `
+Object {
+  "name": "exact",
+  "value": Object {
+    "@computed#foo": Object {
+      "name": "string",
+      "required": true,
+    },
+    "bar": Object {
+      "name": "bool",
+      "required": false,
+    },
+  },
+}
+`;
+
+exports[`getPropType ignores complex computed properties 1`] = `
+Object {
+  "name": "exact",
+  "value": Object {
+    "bar": Object {
+      "name": "bool",
+      "required": false,
+    },
+  },
+}
+`;
+
 exports[`getPropType resolve identifier to their values correctly resolves SpreadElements in arrays 1`] = `
 Object {
   "name": "enum",

--- a/src/utils/__tests__/getMethodDocumentation-test.js
+++ b/src/utils/__tests__/getMethodDocumentation-test.js
@@ -35,6 +35,26 @@ describe('getMethodDocumentation', () => {
         params: [],
       });
     });
+
+    it('handles computed method name', () => {
+      const def = statement(`
+        class Foo {
+          [foo]() {}
+        }
+      `);
+      const method = def.get('body', 'body', 0);
+      expect(getMethodDocumentation(method)).toMatchSnapshot();
+    });
+
+    it('ignores complex computed method name', () => {
+      const def = statement(`
+        class Foo {
+          [() => {}]() {}
+        }
+      `);
+      const method = def.get('body', 'body', 0);
+      expect(getMethodDocumentation(method)).toMatchSnapshot();
+    });
   });
 
   describe('docblock', () => {

--- a/src/utils/__tests__/getPropType-test.js
+++ b/src/utils/__tests__/getPropType-test.js
@@ -338,4 +338,26 @@ describe('getPropType', () => {
       ),
     ).toMatchSnapshot();
   });
+
+  it('handles computed properties', () => {
+    expect(
+      getPropType(
+        expression(`exact({
+      [foo]: string.isRequired,
+      bar: bool
+    })`),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('ignores complex computed properties', () => {
+    expect(
+      getPropType(
+        expression(`exact({
+      [() => {}]: string.isRequired,
+      bar: bool
+    })`),
+      ),
+    ).toMatchSnapshot();
+  });
 });

--- a/src/utils/__tests__/getPropertyName-test.js
+++ b/src/utils/__tests__/getPropertyName-test.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+describe('getPropertyName', () => {
+  let getPropertyName;
+  let expression;
+
+  beforeEach(() => {
+    getPropertyName = require('../getPropertyName').default;
+    ({ expression } = require('../../../tests/utils'));
+  });
+
+  it('returns the name for a normal property', () => {
+    const def = expression('{ foo: 1 }');
+    const param = def.get('properties', 0);
+
+    expect(getPropertyName(param)).toBe('foo');
+  });
+
+  it('returns the name of a object type spread property', () => {
+    const def = expression('(a: { ...foo })');
+    const param = def.get('typeAnnotation', 'typeAnnotation', 'properties', 0);
+
+    expect(getPropertyName(param)).toBe('foo');
+  });
+
+  it('creates name for computed properties', () => {
+    const def = expression('{ [foo]: 21 }');
+    const param = def.get('properties', 0);
+
+    expect(getPropertyName(param)).toBe('@computed#foo');
+  });
+
+  it('creates name for computed properties from string', () => {
+    const def = expression('{ ["foo"]: 21 }');
+    const param = def.get('properties', 0);
+
+    expect(getPropertyName(param)).toBe('@computed#foo');
+  });
+
+  it('creates name for computed properties from int', () => {
+    const def = expression('{ [31]: 21 }');
+    const param = def.get('properties', 0);
+
+    expect(getPropertyName(param)).toBe('@computed#31');
+  });
+
+  it('returns null for computed properties from regex', () => {
+    const def = expression('{ [/31/]: 21 }');
+    const param = def.get('properties', 0);
+
+    expect(getPropertyName(param)).toBe(null);
+  });
+
+  it('returns null for to complex computed properties', () => {
+    const def = expression('{ [() => {}]: 21 }');
+    const param = def.get('properties', 0);
+
+    expect(getPropertyName(param)).toBe(null);
+  });
+});

--- a/src/utils/getMethodDocumentation.js
+++ b/src/utils/getMethodDocumentation.js
@@ -102,8 +102,10 @@ function getMethodModifiers(methodPath) {
 
 export default function getMethodDocumentation(
   methodPath: NodePath,
-): MethodDocumentation {
+): ?MethodDocumentation {
   const name = getPropertyName(methodPath);
+  if (!name) return null;
+
   const docblock = getDocblock(methodPath);
 
   return {

--- a/src/utils/getPropType.js
+++ b/src/utils/getPropType.js
@@ -146,6 +146,8 @@ function getPropTypeShapish(name, argumentPath) {
         return;
       }
 
+      const propertyName = getPropertyName(propertyPath);
+      if (!propertyName) return;
       const descriptor: PropDescriptor | PropTypeDescriptor = getPropType(
         propertyPath.get('value'),
       );
@@ -154,7 +156,7 @@ function getPropTypeShapish(name, argumentPath) {
         descriptor.description = docs;
       }
       descriptor.required = isRequiredPropType(propertyPath.get('value'));
-      value[getPropertyName(propertyPath)] = descriptor;
+      value[propertyName] = descriptor;
     });
     type.value = value;
   }

--- a/src/utils/getPropertyName.js
+++ b/src/utils/getPropertyName.js
@@ -14,16 +14,31 @@ const {
   types: { namedTypes: types },
 } = recast;
 
+export const COMPUTED_PREFIX = '@computed#';
+
 /**
  * In an ObjectExpression, the name of a property can either be an identifier
  * or a literal (or dynamic, but we don't support those). This function simply
  * returns the value of the literal or name of the identifier.
  */
-export default function getPropertyName(propertyPath: NodePath): string {
+export default function getPropertyName(propertyPath: NodePath): ?string {
   if (types.ObjectTypeSpreadProperty.check(propertyPath.node)) {
     return getNameOrValue(propertyPath.get('argument').get('id'), false);
   } else if (propertyPath.node.computed) {
-    throw new TypeError('Property name must be an Identifier or a Literal');
+    if (types.Identifier.check(propertyPath.node.key)) {
+      return `${COMPUTED_PREFIX}${getNameOrValue(
+        propertyPath.get('key'),
+        false,
+      )}`;
+    } else if (
+      types.Literal.check(propertyPath.node.key) &&
+      (typeof propertyPath.node.key.value === 'string' ||
+        typeof propertyPath.node.key.value === 'number')
+    ) {
+      return `${COMPUTED_PREFIX}${propertyPath.node.key.value}`;
+    }
+
+    return null;
   }
 
   return getNameOrValue(propertyPath.get('key'), false);

--- a/src/utils/getPropertyName.js
+++ b/src/utils/getPropertyName.js
@@ -29,7 +29,10 @@ export default function getPropertyName(propertyPath: NodePath): ?string {
     const key = propertyPath.get('key');
 
     // Try to resolve variables and member expressions
-    if (types.Identifier.check(key.node) || types.MemberExpression.check(key.node)) {
+    if (
+      types.Identifier.check(key.node) ||
+      types.MemberExpression.check(key.node)
+    ) {
       const value = resolveToValue(key).node;
 
       if (

--- a/src/utils/isReactComponentMethod.js
+++ b/src/utils/isReactComponentMethod.js
@@ -49,5 +49,5 @@ export default function(methodPath: NodePath): boolean {
   }
 
   const name = getPropertyName(methodPath);
-  return componentMethods.indexOf(name) !== -1;
+  return !!name && componentMethods.indexOf(name) !== -1;
 }

--- a/src/utils/setPropDescription.js
+++ b/src/utils/setPropDescription.js
@@ -11,16 +11,12 @@ import type Documentation from '../Documentation';
 import getPropertyName from './getPropertyName';
 import { getDocblock } from './docblock';
 
-/**
- *
- */
 export default (documentation: Documentation, propertyPath: NodePath) => {
   const propName = getPropertyName(propertyPath);
-  const propDescriptor = documentation.getPropDescriptor(propName);
+  if (!propName) return;
 
-  if (propDescriptor.description) {
-    return;
-  }
+  const propDescriptor = documentation.getPropDescriptor(propName);
+  if (propDescriptor.description) return;
 
   propDescriptor.description = getDocblock(propertyPath) || '';
 };


### PR DESCRIPTION
Fixes #317 

This ignores complex computed properties.
Non complex ones (identifiers, literals) are prefixed with `@computed#` and otherwise handled like normal.