### PR TITLE
Detect components wrapped in HOC with all resolver

### DIFF
--- a/src/resolver/__tests__/findAllComponentDefinitions-test.js
+++ b/src/resolver/__tests__/findAllComponentDefinitions-test.js
@@ -227,4 +227,30 @@ describe('findAllComponentDefinitions', () => {
       expect(result[0].value.type).toEqual('CallExpression');
     });
   });
+
+  describe('regressions', () => {
+    it('finds component wrapped in HOC', () => {
+      const source = `
+        /**
+         * @flow
+         */
+        import * as React from 'react';
+
+        type Props = $ReadOnly<{|
+          tabs: $ReadOnlyArray<string>,
+        |}>;
+
+        const TetraAdminTabs = React.memo<Props>((props: Props) => (
+          <div></div>
+        ));
+
+        export default TetraAdminTabs;
+      `;
+
+      const result = parse(source);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(1);
+      expect(result[0].value.type).toEqual('ArrowFunctionExpression');
+    });
+  });
 });

--- a/src/resolver/findAllComponentDefinitions.js
+++ b/src/resolver/findAllComponentDefinitions.js
@@ -53,13 +53,22 @@ export default function findAllReactCreateClassCalls(
         const inner = resolveToValue(path.get('arguments', 0));
         definitions.delete(inner);
         definitions.add(path);
+
+        // Do not traverse into arguments
+        return false;
       } else if (isReactCreateClassCall(path)) {
         const resolvedPath = resolveToValue(path.get('arguments', 0));
         if (types.ObjectExpression.check(resolvedPath.node)) {
           definitions.add(resolvedPath);
         }
+
+        // Do not traverse into arguments
+        return false;
       }
-      return false;
+
+      // If it is neither of the above cases we need to traverse further
+      // as this call expression could be a HOC
+      this.traverse(path);
     },
   });
 


### PR DESCRIPTION
Fixes #331

This is I think breaking as the following example will now detect a component:

```js
myFunctionCallWhichIsNotAHOC(something, node => (<div>{node}</div>), other);
```

And I don't see a way to workaround this as we cannot detect if a call is a HOC or not.