### PR TITLE
Fix resolving of more than two Flow Utility types

### DIFF
--- a/src/handlers/__tests__/__snapshots__/flowTypeHandler-test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/flowTypeHandler-test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`flowTypeHandler does support utility types inline 1`] = `
+Object {
+  "foo": Object {
+    "description": "",
+    "flowType": Object {},
+    "required": true,
+  },
+}
+`;

--- a/src/handlers/__tests__/flowTypeHandler-test.js
+++ b/src/handlers/__tests__/flowTypeHandler-test.js
@@ -246,6 +246,20 @@ describe('flowTypeHandler', () => {
     });
   });
 
+  it('does support utility types inline', () => {
+    const definition = statement(`
+      (props: $ReadOnly<Props>) => <div />;
+
+      var React = require('React');
+
+      type Props = { foo: 'fooValue' };
+    `).get('expression');
+
+    expect(() => flowTypeHandler(documentation, definition)).not.toThrow();
+
+    expect(documentation.descriptors).toMatchSnapshot();
+  });
+
   it('does not support union proptypes', () => {
     const definition = statement(`
       (props: Props) => <div />;

--- a/src/handlers/flowTypeHandler.js
+++ b/src/handlers/flowTypeHandler.js
@@ -17,20 +17,14 @@ import getFlowTypeFromReactComponent, {
 } from '../utils/getFlowTypeFromReactComponent';
 import resolveToValue from '../utils/resolveToValue';
 import setPropDescription from '../utils/setPropDescription';
-import {
-  isSupportedUtilityType,
-  unwrapUtilityType,
-} from '../utils/flowUtilityTypes';
+import { unwrapUtilityType } from '../utils/flowUtilityTypes';
 
 const {
   types: { namedTypes: types },
 } = recast;
 function setPropDescriptor(documentation: Documentation, path: NodePath): void {
   if (types.ObjectTypeSpreadProperty.check(path.node)) {
-    let argument = path.get('argument');
-    while (isSupportedUtilityType(argument)) {
-      argument = unwrapUtilityType(argument);
-    }
+    const argument = unwrapUtilityType(path.get('argument'));
 
     if (types.ObjectTypeAnnotation.check(argument.node)) {
       applyToFlowTypeProperties(argument, propertyPath => {

--- a/src/utils/__tests__/flowUtilityTypes-test.js
+++ b/src/utils/__tests__/flowUtilityTypes-test.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/*global describe, it, expect*/
+
+import { unwrapUtilityType, isSupportedUtilityType } from '../flowUtilityTypes';
+
+import { statement } from '../../../tests/utils';
+
+describe('flowTypeUtilities', () => {
+  describe('unwrapUtilityType', () => {
+    it('correctly unwraps', () => {
+      const def = statement(`
+        type A = $ReadOnly<{ foo: string }>
+      `);
+
+      expect(unwrapUtilityType(def.get('right'))).toBe(
+        def.get('right', 'typeParameters', 'params', 0),
+      );
+    });
+
+    it('correctly unwraps double', () => {
+      const def = statement(`
+        type A = $ReadOnly<$ReadOnly<{ foo: string }>>
+      `);
+
+      expect(unwrapUtilityType(def.get('right'))).toBe(
+        def.get(
+          'right',
+          'typeParameters',
+          'params',
+          0,
+          'typeParameters',
+          'params',
+          0,
+        ),
+      );
+    });
+
+    it('correctly unwraps triple', () => {
+      const def = statement(`
+        type A = $ReadOnly<$ReadOnly<$ReadOnly<{ foo: string }>>>
+      `);
+
+      expect(unwrapUtilityType(def.get('right'))).toBe(
+        def.get(
+          'right',
+          'typeParameters',
+          'params',
+          0,
+          'typeParameters',
+          'params',
+          0,
+          'typeParameters',
+          'params',
+          0,
+        ),
+      );
+    });
+  });
+
+  describe('isSupportedUtilityType', () => {
+    it('correctly returns true for valid type', () => {
+      const def = statement(`
+        type A = $Exact<{ foo: string }>
+      `);
+
+      expect(isSupportedUtilityType(def.get('right'))).toBe(true);
+    });
+
+    it('correctly returns false for invalid type', () => {
+      const def = statement(`
+        type A = $Homer<{ foo: string }>
+      `);
+
+      expect(isSupportedUtilityType(def.get('right'))).toBe(false);
+    });
+  });
+});

--- a/src/utils/flowUtilityTypes.js
+++ b/src/utils/flowUtilityTypes.js
@@ -21,7 +21,7 @@ const supportedUtilityTypes = new Set(['$Exact', '$ReadOnly']);
 export function isSupportedUtilityType(path: NodePath): boolean {
   if (types.GenericTypeAnnotation.check(path.node)) {
     const idPath = path.get('id');
-    return Boolean(idPath) && supportedUtilityTypes.has(idPath.node.name);
+    return !!idPath && supportedUtilityTypes.has(idPath.node.name);
   }
   return false;
 }
@@ -32,5 +32,9 @@ export function isSupportedUtilityType(path: NodePath): boolean {
  *   $ReadOnly<T> => T
  */
 export function unwrapUtilityType(path: NodePath): NodePath {
-  return path.get('typeParameters', 'params', 0);
+  while (isSupportedUtilityType(path)) {
+    path = path.get('typeParameters', 'params', 0);
+  }
+
+  return path;
 }

--- a/src/utils/getFlowTypeFromReactComponent.js
+++ b/src/utils/getFlowTypeFromReactComponent.js
@@ -11,18 +11,7 @@ import getTypeAnnotation from '../utils/getTypeAnnotation';
 import getMemberValuePath from '../utils/getMemberValuePath';
 import isReactComponentClass from '../utils/isReactComponentClass';
 import isStatelessComponent from '../utils/isStatelessComponent';
-import isUnreachableFlowType from '../utils/isUnreachableFlowType';
-import recast from 'recast';
-import resolveToValue from '../utils/resolveToValue';
-import {
-  isSupportedUtilityType,
-  unwrapUtilityType,
-} from '../utils/flowUtilityTypes';
 import resolveGenericTypeAnnotation from '../utils/resolveGenericTypeAnnotation';
-
-const {
-  types: { namedTypes: types },
-} = recast;
 
 /**
  * Given an React component (stateless or class) tries to find the
@@ -54,21 +43,6 @@ export default (path: NodePath): ?NodePath => {
     const param = path.get('params').get(0);
 
     typePath = getTypeAnnotation(param);
-  }
-
-  if (typePath && isSupportedUtilityType(typePath)) {
-    typePath = unwrapUtilityType(typePath);
-  } else if (typePath && types.GenericTypeAnnotation.check(typePath.node)) {
-    typePath = resolveToValue(typePath.get('id'));
-    if (
-      !typePath ||
-      types.Identifier.check(typePath.node) ||
-      isUnreachableFlowType(typePath)
-    ) {
-      return;
-    }
-
-    typePath = typePath.get('right');
   }
 
   return typePath;

--- a/src/utils/resolveGenericTypeAnnotation.js
+++ b/src/utils/resolveGenericTypeAnnotation.js
@@ -10,7 +10,7 @@
 import isUnreachableFlowType from '../utils/isUnreachableFlowType';
 import recast from 'recast';
 import resolveToValue from '../utils/resolveToValue';
-import { isSupportedUtilityType, unwrapUtilityType } from './flowUtilityTypes';
+import { unwrapUtilityType } from './flowUtilityTypes';
 
 const {
   types: { namedTypes: types },
@@ -25,18 +25,15 @@ export default function resolveGenericTypeAnnotation(
   path: NodePath,
 ): ?NodePath {
   // If the node doesn't have types or properties, try to get the type.
-  let typePath: NodePath = path;
-  if (typePath && isSupportedUtilityType(typePath)) {
-    typePath = unwrapUtilityType(typePath);
-  }
+  let typePath = unwrapUtilityType(path);
 
-  if (typePath && types.GenericTypeAnnotation.check(typePath.node)) {
+  if (types.GenericTypeAnnotation.check(typePath.node)) {
     typePath = resolveToValue(typePath.get('id'));
     if (isUnreachableFlowType(typePath)) {
       return;
     }
 
-    typePath = typePath.get('right');
+    typePath = unwrapUtilityType(typePath.get('right'));
   }
 
   return typePath;

--- a/src/utils/resolveGenericTypeAnnotation.js
+++ b/src/utils/resolveGenericTypeAnnotation.js
@@ -25,11 +25,13 @@ export default function resolveGenericTypeAnnotation(
   path: NodePath,
 ): ?NodePath {
   // If the node doesn't have types or properties, try to get the type.
-  let typePath: ?NodePath;
-  if (path && isSupportedUtilityType(path)) {
-    typePath = unwrapUtilityType(path);
-  } else if (path && types.GenericTypeAnnotation.check(path.node)) {
-    typePath = resolveToValue(path.get('id'));
+  let typePath: NodePath = path;
+  if (typePath && isSupportedUtilityType(typePath)) {
+    typePath = unwrapUtilityType(typePath);
+  }
+
+  if (typePath && types.GenericTypeAnnotation.check(typePath.node)) {
+    typePath = resolveToValue(typePath.get('id'));
     if (isUnreachableFlowType(typePath)) {
       return;
     }

--- a/src/utils/resolveGenericTypeAnnotation.js
+++ b/src/utils/resolveGenericTypeAnnotation.js
@@ -16,15 +16,7 @@ const {
   types: { namedTypes: types },
 } = recast;
 
-/**
- * Given an React component (stateless or class) tries to find the
- * flow type for the props. If not found or not one of the supported
- * component types returns null.
- */
-export default function resolveGenericTypeAnnotation(
-  path: NodePath,
-): ?NodePath {
-  // If the node doesn't have types or properties, try to get the type.
+function tryResolveGenericTypeAnnotation(path: NodePath): ?NodePath {
   let typePath = unwrapUtilityType(path);
 
   if (types.GenericTypeAnnotation.check(typePath.node)) {
@@ -33,8 +25,25 @@ export default function resolveGenericTypeAnnotation(
       return;
     }
 
-    typePath = unwrapUtilityType(typePath.get('right'));
+    return tryResolveGenericTypeAnnotation(typePath.get('right'));
   }
+
+  return typePath;
+}
+
+/**
+ * Given an React component (stateless or class) tries to find the
+ * flow type for the props. If not found or not one of the supported
+ * component types returns undefined.
+ */
+export default function resolveGenericTypeAnnotation(
+  path: NodePath,
+): ?NodePath {
+  if (!path) return;
+
+  const typePath = tryResolveGenericTypeAnnotation(path);
+
+  if (!typePath || typePath === path) return;
 
   return typePath;
 }


### PR DESCRIPTION
We only were resolving up to two levels, because we were doing it in two places :D

```js
type A = $Shape< $Shape< $Shape<B>>>
```

This also refactors the code so that we only do the unwrapping and resolving of types in one single place.