### PR TITLE
TypeScript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,15 +239,15 @@ we are getting this output:
 }
 ```
 
-## Flow Type support
+## Flow and TypeScript support
 
-If you are using [flow][flow] then react-docgen can also extract the flow type annotations. As flow has a way more advanced and fine granular type system, the returned types from react-docgen are different in comparison when using `React.PropTypes`.
+If you are using [flow][flow] or [typescript][typescript] then react-docgen can also extract the type annotations. As flow and typescript have way more advanced and fine granular type systems, the returned types from react-docgen are different in comparison when using `React.PropTypes`.
 
 > **Note**: react-docgen will not be able to grab the type definition if the type is imported or declared in a different file.
 
 ### Example
 
-For the following component
+For the following component with Flow types
 
 ```js
 import React, { Component } from 'react';
@@ -387,6 +387,7 @@ The structure of the JSON blob / JavaScript object is as follows:
         ["raw": string]
       },
       "flowType": <flowType>,
+      "tsType": <tsType>,
       "required": boolean,
       "description": string,
       ["defaultValue": {
@@ -406,9 +407,11 @@ The structure of the JSON blob / JavaScript object is as follows:
 - `<typeName>`: The name of the type, which is usually corresponds to the function name in `React.PropTypes`. However, for types define with `oneOf`, we use `"enum"` and for `oneOfType` we use `"union"`. If a custom function is provided or the type cannot be resolved to anything of `React.PropTypes`, we use `"custom"`.
 - `<typeValue>`: Some types accept parameters which define the type in more detail (such as `arrayOf`, `instanceOf`, `oneOf`, etc). Those are stored in `<typeValue>`. The data type of `<typeValue>` depends on the type definition.
 - `<flowType>`: If using flow type this property contains the parsed flow type as can be seen in the table above.
+- `<tsType>`: If using TypeScript type this property contains the parsed TypeScript type as can be seen in the table above.
 
 [react]: http://facebook.github.io/react/
 [flow]: http://flowtype.org/
+[typescript]: http://typescriptlang.org/
 [recast]: https://github.com/benjamn/recast
 [@babel/parser]: https://github.com/babel/babel/tree/master/packages/babel-parser
 [classes]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "commander": "^2.19.0",
     "doctrine": "^3.0.0",
     "node-dir": "^0.1.10",
-    "recast": "^0.17.3"
+    "recast": "^0.17.6"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "author": "Felix Kling",
   "license": "MIT",
   "dependencies": {
-    "@babel/core": "^7.0.0",
+    "@babel/core": "^7.4.4",
     "@babel/runtime": "^7.0.0",
     "async": "^2.1.4",
     "commander": "^2.19.0",
@@ -47,7 +47,6 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
-    "@babel/core": "^7.0.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/plugin-transform-runtime": "^7.0.0",
     "@babel/preset-env": "^7.0.0",

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -1057,14 +1057,15 @@ Object {
   "props": Object {
     "bar": Object {
       "description": "Required prop",
-      "flowType": Object {
+      "required": true,
+      "tsType": Object {
         "name": "number",
       },
-      "required": true,
     },
     "baz": Object {
       "description": "Complex union prop",
-      "flowType": Object {
+      "required": true,
+      "tsType": Object {
         "elements": Array [
           Object {
             "name": "number",
@@ -1100,14 +1101,13 @@ Object {
         "name": "union",
         "raw": "number | { enter?: number, exit?: number } | 'auto'",
       },
-      "required": true,
     },
     "foo": Object {
       "description": "Optional prop",
-      "flowType": Object {
+      "required": false,
+      "tsType": Object {
         "name": "string",
       },
-      "required": false,
     },
   },
 }
@@ -1121,7 +1121,8 @@ Object {
   "props": Object {
     "align": Object {
       "description": "",
-      "flowType": Object {
+      "required": false,
+      "tsType": Object {
         "elements": Array [
           Object {
             "name": "literal",
@@ -1143,35 +1144,34 @@ Object {
         "name": "union",
         "raw": "\\"left\\" | \\"center\\" | \\"right\\" | \\"justify\\"",
       },
-      "required": false,
     },
     "center": Object {
       "description": "",
-      "flowType": Object {
+      "required": false,
+      "tsType": Object {
         "name": "boolean",
       },
-      "required": false,
     },
     "justify": Object {
       "description": "",
-      "flowType": Object {
+      "required": false,
+      "tsType": Object {
         "name": "boolean",
       },
-      "required": false,
     },
     "left": Object {
       "description": "",
-      "flowType": Object {
+      "required": false,
+      "tsType": Object {
         "name": "boolean",
       },
-      "required": false,
     },
     "right": Object {
       "description": "",
-      "flowType": Object {
+      "required": false,
+      "tsType": Object {
         "name": "boolean",
       },
-      "required": false,
     },
   },
 }
@@ -1188,14 +1188,15 @@ Object {
   "props": Object {
     "bar": Object {
       "description": "Required prop",
-      "flowType": Object {
+      "required": true,
+      "tsType": Object {
         "name": "number",
       },
-      "required": true,
     },
     "baz": Object {
       "description": "Complex union prop",
-      "flowType": Object {
+      "required": true,
+      "tsType": Object {
         "elements": Array [
           Object {
             "name": "number",
@@ -1231,14 +1232,13 @@ Object {
         "name": "union",
         "raw": "number | { enter?: number, exit?: number } | 'auto'",
       },
-      "required": true,
     },
     "foo": Object {
       "description": "Optional prop",
-      "flowType": Object {
+      "required": false,
+      "tsType": Object {
         "name": "string",
       },
-      "required": false,
     },
   },
 }

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -1179,6 +1179,9 @@ Object {
 
 exports[`main fixtures processes component "component_23.tsx" without errors 1`] = `
 Object {
+  "composes": Array [
+    "OtherProps",
+  ],
   "description": "This is a typescript class component",
   "displayName": "TSComponent",
   "methods": Array [],
@@ -1243,6 +1246,9 @@ Object {
 
 exports[`main fixtures processes component "component_24.js" without errors 1`] = `
 Object {
+  "composes": Array [
+    "OtherProps",
+  ],
   "description": "This is a flow class component with an interface as props",
   "displayName": "FlowComponent",
   "methods": Array [],

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -1384,3 +1384,40 @@ Object {
   },
 }
 `;
+
+exports[`main fixtures processes component "component_27.tsx" without errors 1`] = `
+Object {
+  "description": "This is a typescript class component",
+  "displayName": "TSComponent",
+  "methods": Array [
+    Object {
+      "description": "This is a method",
+      "docblock": "This is a method",
+      "modifiers": Array [],
+      "name": "method",
+      "params": Array [
+        Object {
+          "name": "a",
+          "type": Object {
+            "name": "string",
+          },
+        },
+      ],
+      "returns": Object {
+        "type": Object {
+          "name": "string",
+        },
+      },
+    },
+  ],
+  "props": Object {
+    "foo": Object {
+      "description": "",
+      "required": true,
+      "tsType": Object {
+        "name": "string",
+      },
+    },
+  },
+}
+`;

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -1048,3 +1048,131 @@ Object {
   },
 }
 `;
+
+exports[`main fixtures processes component "component_21.tsx" without errors 1`] = `
+Object {
+  "description": "This is a typescript class component",
+  "displayName": "TSComponent",
+  "methods": Array [],
+  "props": Object {
+    "bar": Object {
+      "description": "Required prop",
+      "flowType": Object {
+        "name": "number",
+      },
+      "required": true,
+    },
+    "baz": Object {
+      "description": "Complex union prop",
+      "flowType": Object {
+        "elements": Array [
+          Object {
+            "name": "number",
+          },
+          Object {
+            "name": "signature",
+            "raw": "{ enter?: number, exit?: number }",
+            "signature": Object {
+              "properties": Array [
+                Object {
+                  "key": "enter",
+                  "value": Object {
+                    "name": "number",
+                    "required": false,
+                  },
+                },
+                Object {
+                  "key": "exit",
+                  "value": Object {
+                    "name": "number",
+                    "required": false,
+                  },
+                },
+              ],
+            },
+            "type": "object",
+          },
+          Object {
+            "name": "literal",
+            "value": "'auto'",
+          },
+        ],
+        "name": "union",
+        "raw": "number | { enter?: number, exit?: number } | 'auto'",
+      },
+      "required": true,
+    },
+    "foo": Object {
+      "description": "Optional prop",
+      "flowType": Object {
+        "name": "string",
+      },
+      "required": false,
+    },
+  },
+}
+`;
+
+exports[`main fixtures processes component "component_22.tsx" without errors 1`] = `
+Object {
+  "description": "This is a TypeScript function component",
+  "displayName": "TSFunctionComponent",
+  "methods": Array [],
+  "props": Object {
+    "align": Object {
+      "description": "",
+      "flowType": Object {
+        "elements": Array [
+          Object {
+            "name": "literal",
+            "value": "\\"left\\"",
+          },
+          Object {
+            "name": "literal",
+            "value": "\\"center\\"",
+          },
+          Object {
+            "name": "literal",
+            "value": "\\"right\\"",
+          },
+          Object {
+            "name": "literal",
+            "value": "\\"justify\\"",
+          },
+        ],
+        "name": "union",
+        "raw": "\\"left\\" | \\"center\\" | \\"right\\" | \\"justify\\"",
+      },
+      "required": false,
+    },
+    "center": Object {
+      "description": "",
+      "flowType": Object {
+        "name": "boolean",
+      },
+      "required": false,
+    },
+    "justify": Object {
+      "description": "",
+      "flowType": Object {
+        "name": "boolean",
+      },
+      "required": false,
+    },
+    "left": Object {
+      "description": "",
+      "flowType": Object {
+        "name": "boolean",
+      },
+      "required": false,
+    },
+    "right": Object {
+      "description": "",
+      "flowType": Object {
+        "name": "boolean",
+      },
+      "required": false,
+    },
+  },
+}
+`;

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -1176,3 +1176,131 @@ Object {
   },
 }
 `;
+
+exports[`main fixtures processes component "component_23.tsx" without errors 1`] = `
+Object {
+  "description": "This is a typescript class component",
+  "displayName": "TSComponent",
+  "methods": Array [],
+  "props": Object {
+    "bar": Object {
+      "description": "Required prop",
+      "flowType": Object {
+        "name": "number",
+      },
+      "required": true,
+    },
+    "baz": Object {
+      "description": "Complex union prop",
+      "flowType": Object {
+        "elements": Array [
+          Object {
+            "name": "number",
+          },
+          Object {
+            "name": "signature",
+            "raw": "{ enter?: number, exit?: number }",
+            "signature": Object {
+              "properties": Array [
+                Object {
+                  "key": "enter",
+                  "value": Object {
+                    "name": "number",
+                    "required": false,
+                  },
+                },
+                Object {
+                  "key": "exit",
+                  "value": Object {
+                    "name": "number",
+                    "required": false,
+                  },
+                },
+              ],
+            },
+            "type": "object",
+          },
+          Object {
+            "name": "literal",
+            "value": "'auto'",
+          },
+        ],
+        "name": "union",
+        "raw": "number | { enter?: number, exit?: number } | 'auto'",
+      },
+      "required": true,
+    },
+    "foo": Object {
+      "description": "Optional prop",
+      "flowType": Object {
+        "name": "string",
+      },
+      "required": false,
+    },
+  },
+}
+`;
+
+exports[`main fixtures processes component "component_24.js" without errors 1`] = `
+Object {
+  "description": "This is a flow class component with an interface as props",
+  "displayName": "FlowComponent",
+  "methods": Array [],
+  "props": Object {
+    "bar": Object {
+      "description": "Required prop",
+      "flowType": Object {
+        "name": "number",
+      },
+      "required": true,
+    },
+    "baz": Object {
+      "description": "Complex union prop",
+      "flowType": Object {
+        "elements": Array [
+          Object {
+            "name": "number",
+          },
+          Object {
+            "name": "signature",
+            "raw": "{ enter?: number, exit?: number }",
+            "signature": Object {
+              "properties": Array [
+                Object {
+                  "key": "enter",
+                  "value": Object {
+                    "name": "number",
+                    "required": false,
+                  },
+                },
+                Object {
+                  "key": "exit",
+                  "value": Object {
+                    "name": "number",
+                    "required": false,
+                  },
+                },
+              ],
+            },
+            "type": "object",
+          },
+          Object {
+            "name": "literal",
+            "value": "'auto'",
+          },
+        ],
+        "name": "union",
+        "raw": "number | { enter?: number, exit?: number } | 'auto'",
+      },
+      "required": true,
+    },
+    "foo": Object {
+      "description": "Optional prop",
+      "flowType": Object {
+        "name": "string",
+      },
+      "required": false,
+    },
+  },
+}
+`;

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -1310,3 +1310,77 @@ Object {
   },
 }
 `;
+
+exports[`main fixtures processes component "component_25.tsx" without errors 1`] = `
+Object {
+  "description": "This is a typescript class component",
+  "displayName": "TSComponent",
+  "methods": Array [],
+  "props": Object {
+    "bar": Object {
+      "description": "Required prop",
+      "required": true,
+      "tsType": Object {
+        "elements": Array [
+          Object {
+            "name": "Child",
+          },
+        ],
+        "name": "Array",
+        "raw": "Array<X>",
+      },
+    },
+    "baz": Object {
+      "description": "Complex union prop",
+      "required": true,
+      "tsType": Object {
+        "name": "number",
+      },
+    },
+    "foo": Object {
+      "description": "Optional prop",
+      "required": false,
+      "tsType": Object {
+        "name": "Child",
+      },
+    },
+  },
+}
+`;
+
+exports[`main fixtures processes component "component_26.js" without errors 1`] = `
+Object {
+  "description": "This is a typescript class component",
+  "displayName": "FlowComponent",
+  "methods": Array [],
+  "props": Object {
+    "bar": Object {
+      "description": "Required prop",
+      "flowType": Object {
+        "elements": Array [
+          Object {
+            "name": "Child",
+          },
+        ],
+        "name": "Array",
+        "raw": "Array<X>",
+      },
+      "required": true,
+    },
+    "baz": Object {
+      "description": "Complex union prop",
+      "flowType": Object {
+        "name": "number",
+      },
+      "required": true,
+    },
+    "foo": Object {
+      "description": "Optional prop",
+      "flowType": Object {
+        "name": "Child",
+      },
+      "required": false,
+    },
+  },
+}
+`;

--- a/src/__tests__/fixtures/component_21.tsx
+++ b/src/__tests__/fixtures/component_21.tsx
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React, { Component } from 'react';
+
+type BaseProps = {
+  /** Optional prop */
+  foo?: string,
+  /** Required prop */
+  bar: number
+};
+
+type TransitionDuration = number | { enter?: number, exit?: number } | 'auto';
+
+type Props = BaseProps & {
+  /** Complex union prop */
+  baz: TransitionDuration
+}
+
+/**
+ * This is a typescript class component
+ */
+export default class TSComponent extends Component<Props> {
+  render() {
+    return <h1>Hello world</h1>;
+  }
+}

--- a/src/__tests__/fixtures/component_22.tsx
+++ b/src/__tests__/fixtures/component_22.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+type Props = {
+  align?: "left" | "center" | "right" | "justify",
+  left?: boolean,
+  center?: boolean,
+  right?: boolean,
+  justify?: boolean,
+};
+
+/**
+ * This is a TypeScript function component
+ */
+export function TSFunctionComponent(props: Props) {
+  return <h1>Hello world</h1>;
+}

--- a/src/__tests__/fixtures/component_23.tsx
+++ b/src/__tests__/fixtures/component_23.tsx
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React, { Component } from 'react';
+
+interface BaseProps {
+  /** Optional prop */
+  foo?: string,
+  /** Required prop */
+  bar: number
+}
+
+type TransitionDuration = number | { enter?: number, exit?: number } | 'auto';
+
+interface Props extends BaseProps {
+  /** Complex union prop */
+  baz: TransitionDuration
+}
+
+/**
+ * This is a typescript class component
+ */
+export default class TSComponent extends Component<Props> {
+  render() {
+    return <h1>Hello world</h1>;
+  }
+}

--- a/src/__tests__/fixtures/component_23.tsx
+++ b/src/__tests__/fixtures/component_23.tsx
@@ -17,7 +17,7 @@ interface BaseProps {
 
 type TransitionDuration = number | { enter?: number, exit?: number } | 'auto';
 
-interface Props extends BaseProps {
+interface Props extends BaseProps, OtherProps {
   /** Complex union prop */
   baz: TransitionDuration
 }

--- a/src/__tests__/fixtures/component_24.js
+++ b/src/__tests__/fixtures/component_24.js
@@ -17,7 +17,7 @@ interface BaseProps {
 
 type TransitionDuration = number | { enter?: number, exit?: number } | 'auto';
 
-interface Props extends BaseProps {
+interface Props extends BaseProps, OtherProps {
   /** Complex union prop */
   baz: TransitionDuration
 }

--- a/src/__tests__/fixtures/component_24.js
+++ b/src/__tests__/fixtures/component_24.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React, { Component } from 'react';
+
+interface BaseProps {
+  /** Optional prop */
+  foo?: string,
+  /** Required prop */
+  bar: number
+}
+
+type TransitionDuration = number | { enter?: number, exit?: number } | 'auto';
+
+interface Props extends BaseProps {
+  /** Complex union prop */
+  baz: TransitionDuration
+}
+
+/**
+ * This is a flow class component with an interface as props
+ */
+export default class FlowComponent extends Component<Props> {
+  render() {
+    return <h1>Hello world</h1>;
+  }
+}

--- a/src/__tests__/fixtures/component_25.tsx
+++ b/src/__tests__/fixtures/component_25.tsx
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React, { Component } from 'react';
+
+type Test<X> = Array<X>;
+interface BaseProps<T> {
+  /** Optional prop */
+  foo?: T,
+  /** Required prop */
+  bar: Test<T>
+}
+
+interface Child {}
+
+interface Props extends BaseProps<Child> {
+  /** Complex union prop */
+  baz: number
+}
+
+/**
+ * This is a typescript class component
+ */
+export default class TSComponent extends Component<Props> {
+  render() {
+    return <h1>Hello world</h1>;
+  }
+}

--- a/src/__tests__/fixtures/component_26.js
+++ b/src/__tests__/fixtures/component_26.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React, { Component } from 'react';
+
+type Test<X> = Array<X>;
+interface BaseProps<T> {
+  /** Optional prop */
+  foo?: T,
+  /** Required prop */
+  bar: Test<T>
+}
+
+interface Child {}
+
+interface Props extends BaseProps<Child> {
+  /** Complex union prop */
+  baz: number
+}
+
+/**
+ * This is a typescript class component
+ */
+export default class FlowComponent extends Component<Props> {
+  render() {
+    return <h1>Hello world</h1>;
+  }
+}

--- a/src/__tests__/fixtures/component_27.tsx
+++ b/src/__tests__/fixtures/component_27.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React, { Component } from 'react';
+
+interface Props {
+  foo: string
+}
+
+/**
+ * This is a typescript class component
+ */
+export default class TSComponent extends Component<Props> {
+  render() {
+    return <h1>Hello world</h1>;
+  }
+
+  /**
+   * This is a method
+   */
+  method(a: string): string {
+    return a;
+  }
+}

--- a/src/__tests__/main-test.js
+++ b/src/__tests__/main-test.js
@@ -225,12 +225,16 @@ describe('main', () => {
     const fixturePath = path.join(__dirname, 'fixtures');
     const fileNames = fs.readdirSync(fixturePath);
     for (let i = 0; i < fileNames.length; i++) {
-      const fileContent = fs.readFileSync(path.join(fixturePath, fileNames[i]));
+      const filePath = path.join(fixturePath, fileNames[i]);
+      const fileContent = fs.readFileSync(filePath);
 
       it(`processes component "${fileNames[i]}" without errors`, () => {
         let result;
         expect(() => {
-          result = docgen.parse(fileContent);
+          result = docgen.parse(fileContent, null, null, {
+            filename: filePath,
+            babelrc: false,
+          });
         }).not.toThrowError();
         expect(result).toMatchSnapshot();
       });

--- a/src/babelParser.js
+++ b/src/babelParser.js
@@ -8,32 +8,42 @@
  */
 
 const babel = require('@babel/core');
+const path = require('path');
 
-const defaultPlugins = [
-  'jsx',
-  'flow',
-  'asyncGenerators',
-  'bigInt',
-  'classProperties',
-  'classPrivateProperties',
-  'classPrivateMethods',
-  ['decorators', { decoratorsBeforeExport: false }],
-  'doExpressions',
-  'dynamicImport',
-  'exportDefaultFrom',
-  'exportNamespaceFrom',
-  'functionBind',
-  'functionSent',
-  'importMeta',
-  'logicalAssignment',
-  'nullishCoalescingOperator',
-  'numericSeparator',
-  'objectRestSpread',
-  'optionalCatchBinding',
-  'optionalChaining',
-  ['pipelineOperator', { proposal: 'minimal' }],
-  'throwExpressions',
-];
+const TYPESCRIPT_EXTS = {
+  '.ts': true,
+  '.tsx': true,
+};
+
+function getDefaultPlugins(options: BabelOptions) {
+  return [
+    'jsx',
+    TYPESCRIPT_EXTS[path.extname(options.filename || '')]
+      ? 'typescript'
+      : 'flow',
+    'asyncGenerators',
+    'bigInt',
+    'classProperties',
+    'classPrivateProperties',
+    'classPrivateMethods',
+    ['decorators', { decoratorsBeforeExport: false }],
+    'doExpressions',
+    'dynamicImport',
+    'exportDefaultFrom',
+    'exportNamespaceFrom',
+    'functionBind',
+    'functionSent',
+    'importMeta',
+    'logicalAssignment',
+    'nullishCoalescingOperator',
+    'numericSeparator',
+    'objectRestSpread',
+    'optionalCatchBinding',
+    'optionalChaining',
+    ['pipelineOperator', { proposal: 'minimal' }],
+    'throwExpressions',
+  ];
+}
 
 type ParserOptions = {
   plugins?: Array<string | [string, {}]>,
@@ -73,7 +83,7 @@ function buildOptions(
   const partialConfig = babel.loadPartialConfig(babelOptions);
 
   if (!partialConfig.hasFilesystemConfig() && parserOpts.plugins.length === 0) {
-    parserOpts.plugins = [...defaultPlugins];
+    parserOpts.plugins = getDefaultPlugins(babelOptions);
   }
 
   // Recast needs tokens to be in the tree

--- a/src/handlers/flowTypeHandler.js
+++ b/src/handlers/flowTypeHandler.js
@@ -66,7 +66,7 @@ function setPropDescriptor(documentation: Documentation, path: NodePath): void {
 
     const propDescriptor = documentation.getPropDescriptor(propName);
     propDescriptor.required = !path.node.optional;
-    propDescriptor.flowType = type;
+    propDescriptor.tsType = type;
 
     // We are doing this here instead of in a different handler
     // to not need to duplicate the logic for checking for

--- a/src/handlers/flowTypeHandler.js
+++ b/src/handlers/flowTypeHandler.js
@@ -28,7 +28,7 @@ function setPropDescriptor(documentation: Documentation, path: NodePath): void {
     const argument = unwrapUtilityType(path.get('argument'));
 
     if (types.ObjectTypeAnnotation.check(argument.node)) {
-      applyToFlowTypeProperties(argument, propertyPath => {
+      applyToFlowTypeProperties(documentation, argument, propertyPath => {
         setPropDescriptor(documentation, propertyPath);
       });
       return;
@@ -39,7 +39,7 @@ function setPropDescriptor(documentation: Documentation, path: NodePath): void {
 
     if (resolvedPath && types.TypeAlias.check(resolvedPath.node)) {
       const right = resolvedPath.get('right');
-      applyToFlowTypeProperties(right, propertyPath => {
+      applyToFlowTypeProperties(documentation, right, propertyPath => {
         setPropDescriptor(documentation, propertyPath);
       });
     } else {
@@ -90,7 +90,7 @@ export default function flowTypeHandler(
     return;
   }
 
-  applyToFlowTypeProperties(flowTypesPath, propertyPath => {
+  applyToFlowTypeProperties(documentation, flowTypesPath, propertyPath => {
     setPropDescriptor(documentation, propertyPath);
   });
 }

--- a/src/handlers/flowTypeHandler.js
+++ b/src/handlers/flowTypeHandler.js
@@ -11,6 +11,7 @@ import recast from 'recast';
 import type Documentation from '../Documentation';
 
 import getFlowType from '../utils/getFlowType';
+import getTSType from '../utils/getTSType';
 import getPropertyName from '../utils/getPropertyName';
 import getFlowTypeFromReactComponent, {
   applyToFlowTypeProperties,
@@ -46,6 +47,20 @@ function setPropDescriptor(documentation: Documentation, path: NodePath): void {
     }
   } else if (types.ObjectTypeProperty.check(path.node)) {
     const type = getFlowType(path.get('value'));
+    const propName = getPropertyName(path);
+    if (!propName) return;
+
+    const propDescriptor = documentation.getPropDescriptor(propName);
+    propDescriptor.required = !path.node.optional;
+    propDescriptor.flowType = type;
+
+    // We are doing this here instead of in a different handler
+    // to not need to duplicate the logic for checking for
+    // imported types that are spread in to props.
+    setPropDescription(documentation, path);
+  } else if (types.TSPropertySignature.check(path.node)) {
+    const type = getTSType(path.get('typeAnnotation'));
+
     const propName = getPropertyName(path);
     if (!propName) return;
 

--- a/src/resolver/__tests__/findAllExportedComponentDefinitions-test.js
+++ b/src/resolver/__tests__/findAllExportedComponentDefinitions-test.js
@@ -867,7 +867,7 @@ describe('findAllExportedComponentDefinitions', () => {
 
           parsed = parse(`
             import React from "React"
-
+            var foo = 42;
             var Component = React.createClass({});
             export {Component, foo}
           `);

--- a/src/resolver/__tests__/findExportedComponentDefinition-test.js
+++ b/src/resolver/__tests__/findExportedComponentDefinition-test.js
@@ -617,6 +617,7 @@ describe('findExportedComponentDefinition', () => {
 
           source = `
             import React from "React"
+            var foo = 42;
             var Component = React.createClass({});
             export {Component, foo}
           `;

--- a/src/types.js
+++ b/src/types.js
@@ -59,12 +59,18 @@ export type FlowElementsType = FlowBaseType & {
   elements: Array<FlowTypeDescriptor>,
 };
 
+export type FlowFunctionArgumentType = {
+  name: string,
+  type: FlowTypeDescriptor,
+  rest?: boolean,
+};
+
 export type FlowFunctionSignatureType = FlowBaseType & {
   name: 'signature',
   type: 'function',
   raw: string,
   signature: {
-    arguments: Array<{ name: string, type: FlowTypeDescriptor }>,
+    arguments: Array<FlowFunctionArgumentType>,
     return: FlowTypeDescriptor,
   },
 };

--- a/src/utils/__tests__/getFlowType-test.js
+++ b/src/utils/__tests__/getFlowType-test.js
@@ -216,7 +216,9 @@ describe('getFlowType', () => {
   });
 
   it('detects function signature type', () => {
-    const typePath = expression('x: (p1: number, p2: ?string) => boolean')
+    const typePath = expression(
+      'x: (p1: number, p2: ?string, ...rest: Array<string>) => boolean',
+    )
       .get('typeAnnotation')
       .get('typeAnnotation');
     expect(getFlowType(typePath)).toEqual({
@@ -226,10 +228,19 @@ describe('getFlowType', () => {
         arguments: [
           { name: 'p1', type: { name: 'number' } },
           { name: 'p2', type: { name: 'string', nullable: true } },
+          {
+            name: 'rest',
+            rest: true,
+            type: {
+              name: 'Array',
+              elements: [{ name: 'string' }],
+              raw: 'Array<string>',
+            },
+          },
         ],
         return: { name: 'boolean' },
       },
-      raw: '(p1: number, p2: ?string) => boolean',
+      raw: '(p1: number, p2: ?string, ...rest: Array<string>) => boolean',
     });
   });
 
@@ -265,6 +276,7 @@ describe('getFlowType', () => {
       raw: 'string => boolean',
     });
   });
+
   it('detects callable signature type', () => {
     const typePath = expression('x: { (str: string): string, token: string }')
       .get('typeAnnotation')

--- a/src/utils/__tests__/getFlowType-test.js
+++ b/src/utils/__tests__/getFlowType-test.js
@@ -436,6 +436,44 @@ describe('getFlowType', () => {
     });
   });
 
+  it('handles generic types', () => {
+    const typePath = statement(`
+      var x: MyType<string> = {};
+
+      type MyType<T> = { a: T, b: Array<T> };
+    `)
+      .get('declarations', 0)
+      .get('id')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+
+    expect(getFlowType(typePath)).toEqual({
+      name: 'signature',
+      type: 'object',
+      raw: '{ a: T, b: Array<T> }',
+      signature: {
+        properties: [
+          {
+            key: 'a',
+            value: {
+              name: 'string',
+              required: true,
+            },
+          },
+          {
+            key: 'b',
+            value: {
+              name: 'Array',
+              raw: 'Array<T>',
+              required: true,
+              elements: [{ name: 'string' }],
+            },
+          },
+        ],
+      },
+    });
+  });
+
   describe('React types', () => {
     function test(type, expected) {
       const typePath = statement(`

--- a/src/utils/__tests__/getTSType-test.js
+++ b/src/utils/__tests__/getTSType-test.js
@@ -1,0 +1,599 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/* global jest, describe, beforeEach, it, expect */
+
+jest.disableAutomock();
+
+describe('getTSType', () => {
+  let expression, statement;
+  let getTSType;
+
+  beforeEach(() => {
+    getTSType = require('../getTSType').default;
+    const {
+      expression: expr,
+      statement: stmt,
+    } = require('../../../tests/utils');
+    expression = code =>
+      expr(code, undefined, {
+        filename: 'test.ts',
+        babelrc: false,
+      });
+    statement = code =>
+      stmt(code, undefined, {
+        filename: 'test.ts',
+        babelrc: false,
+      });
+  });
+
+  it('detects simple types', () => {
+    const simplePropTypes = [
+      'string',
+      'number',
+      'boolean',
+      'symbol',
+      'object',
+      'any',
+      'unknown',
+      'null',
+      'undefined',
+      'void',
+      'Object',
+      'Function',
+      'Boolean',
+      'String',
+      'Number',
+    ];
+
+    simplePropTypes.forEach(type => {
+      const typePath = expression('x: ' + type)
+        .get('typeAnnotation')
+        .get('typeAnnotation');
+      expect(getTSType(typePath)).toEqual({ name: type });
+    });
+  });
+
+  it('detects literal types', () => {
+    const literalTypes = ['"foo"', 1234, true];
+
+    literalTypes.forEach(value => {
+      const typePath = expression(`x: ${value}`)
+        .get('typeAnnotation')
+        .get('typeAnnotation');
+      expect(getTSType(typePath)).toEqual({
+        name: 'literal',
+        value: `${value}`,
+      });
+    });
+  });
+
+  it('detects external type', () => {
+    const typePath = expression('x: xyz')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+    expect(getTSType(typePath)).toEqual({ name: 'xyz' });
+  });
+
+  it('detects array type shorthand', () => {
+    const typePath = expression('x: number[]')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+    expect(getTSType(typePath)).toEqual({
+      name: 'Array',
+      elements: [{ name: 'number' }],
+      raw: 'number[]',
+    });
+  });
+
+  it('detects array type', () => {
+    const typePath = expression('x: Array<number>')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+    expect(getTSType(typePath)).toEqual({
+      name: 'Array',
+      elements: [{ name: 'number' }],
+      raw: 'Array<number>',
+    });
+  });
+
+  it('detects array type with multiple types', () => {
+    const typePath = expression('x: Array<number, xyz>')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+    expect(getTSType(typePath)).toEqual({
+      name: 'Array',
+      elements: [{ name: 'number' }, { name: 'xyz' }],
+      raw: 'Array<number, xyz>',
+    });
+  });
+
+  it('detects class type', () => {
+    const typePath = expression('x: Class<Boolean>')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+    expect(getTSType(typePath)).toEqual({
+      name: 'Class',
+      elements: [{ name: 'Boolean' }],
+      raw: 'Class<Boolean>',
+    });
+  });
+
+  it('detects function type with subtype', () => {
+    const typePath = expression('x: Function<xyz>')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+    expect(getTSType(typePath)).toEqual({
+      name: 'Function',
+      elements: [{ name: 'xyz' }],
+      raw: 'Function<xyz>',
+    });
+  });
+
+  it('detects object types', () => {
+    const typePath = expression('x: { a: string, b?: xyz }')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+    expect(getTSType(typePath)).toEqual({
+      name: 'signature',
+      type: 'object',
+      signature: {
+        properties: [
+          { key: 'a', value: { name: 'string', required: true } },
+          { key: 'b', value: { name: 'xyz', required: false } },
+        ],
+      },
+      raw: '{ a: string, b?: xyz }',
+    });
+  });
+
+  it('detects union type', () => {
+    const typePath = expression('x: string | xyz | "foo" | void')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+    expect(getTSType(typePath)).toEqual({
+      name: 'union',
+      elements: [
+        { name: 'string' },
+        { name: 'xyz' },
+        { name: 'literal', value: '"foo"' },
+        { name: 'void' },
+      ],
+      raw: 'string | xyz | "foo" | void',
+    });
+  });
+
+  it('detects intersection type', () => {
+    const typePath = expression('x: string & xyz & "foo" & void')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+    expect(getTSType(typePath)).toEqual({
+      name: 'intersection',
+      elements: [
+        { name: 'string' },
+        { name: 'xyz' },
+        { name: 'literal', value: '"foo"' },
+        { name: 'void' },
+      ],
+      raw: 'string & xyz & "foo" & void',
+    });
+  });
+
+  it('detects function signature type', () => {
+    const typePath = expression('x: (p1: number, p2: string) => boolean')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+    expect(getTSType(typePath)).toEqual({
+      name: 'signature',
+      type: 'function',
+      signature: {
+        arguments: [
+          { name: 'p1', type: { name: 'number' } },
+          { name: 'p2', type: { name: 'string' } },
+        ],
+        return: { name: 'boolean' },
+      },
+      raw: '(p1: number, p2: string) => boolean',
+    });
+  });
+
+  it('detects callable signature type', () => {
+    const typePath = expression('x: { (str: string): string, token: string }')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+    expect(getTSType(typePath)).toEqual({
+      name: 'signature',
+      type: 'object',
+      signature: {
+        constructor: {
+          name: 'signature',
+          type: 'function',
+          signature: {
+            arguments: [{ name: 'str', type: { name: 'string' } }],
+            return: { name: 'string' },
+          },
+          raw: '(str: string): string,', // TODO: why does it print a comma?
+        },
+        properties: [
+          { key: 'token', value: { name: 'string', required: true } },
+        ],
+      },
+      raw: '{ (str: string): string, token: string }',
+    });
+  });
+
+  it('detects map signature', () => {
+    const typePath = expression(
+      'x: { [key: string]: number, [key: "xl"]: string, token: "a" | "b" }',
+    )
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+    expect(getTSType(typePath)).toEqual({
+      name: 'signature',
+      type: 'object',
+      signature: {
+        properties: [
+          {
+            key: { name: 'string' },
+            value: { name: 'number', required: true },
+          },
+          {
+            key: { name: 'literal', value: '"xl"' },
+            value: { name: 'string', required: true },
+          },
+          {
+            key: 'token',
+            value: {
+              name: 'union',
+              required: true,
+              raw: '"a" | "b"',
+              elements: [
+                { name: 'literal', value: '"a"' },
+                { name: 'literal', value: '"b"' },
+              ],
+            },
+          },
+        ],
+      },
+      raw: '{ [key: string]: number, [key: "xl"]: string, token: "a" | "b" }',
+    });
+  });
+
+  it('detects tuple signature', () => {
+    const typePath = expression('x: [string, number]')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+    expect(getTSType(typePath)).toEqual({
+      name: 'tuple',
+      elements: [{ name: 'string' }, { name: 'number' }],
+      raw: '[string, number]',
+    });
+  });
+
+  it('detects tuple in union signature', () => {
+    const typePath = expression('x: [string, number] | [number, string]')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+    expect(getTSType(typePath)).toEqual({
+      name: 'union',
+      elements: [
+        {
+          name: 'tuple',
+          elements: [{ name: 'string' }, { name: 'number' }],
+          raw: '[string, number]',
+        },
+        {
+          name: 'tuple',
+          elements: [{ name: 'number' }, { name: 'string' }],
+          raw: '[number, string]',
+        },
+      ],
+      raw: '[string, number] | [number, string]',
+    });
+  });
+
+  it('resolves types in scope', () => {
+    const typePath = statement(`
+      var x: MyType = 2;
+
+      type MyType = string;
+    `)
+      .get('declarations', 0)
+      .get('id')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+
+    expect(getTSType(typePath)).toEqual({ name: 'string' });
+  });
+
+  it('handles typeof types', () => {
+    const typePath = statement(`
+      var x: typeof MyType = {};
+
+      type MyType = { a: string, b: xyz };
+    `)
+      .get('declarations', 0)
+      .get('id')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+
+    expect(getTSType(typePath)).toEqual({
+      name: 'signature',
+      type: 'object',
+      signature: {
+        properties: [
+          { key: 'a', value: { name: 'string', required: true } },
+          { key: 'b', value: { name: 'xyz', required: true } },
+        ],
+      },
+      raw: '{ a: string, b: xyz }',
+    });
+  });
+
+  it('handles qualified type identifiers', () => {
+    const typePath = statement(`
+      var x: MyType.x = {};
+
+      type MyType = { a: string, b: xyz };
+    `)
+      .get('declarations', 0)
+      .get('id')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+
+    expect(getTSType(typePath)).toEqual({
+      name: 'MyType.x',
+    });
+  });
+
+  it('handles qualified type identifiers with params', () => {
+    const typePath = statement(`
+      var x: MyType.x<any> = {};
+
+      type MyType = { a: string, b: xyz };
+    `)
+      .get('declarations', 0)
+      .get('id')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+
+    expect(getTSType(typePath)).toEqual({
+      name: 'MyType.x',
+      raw: 'MyType.x<any>',
+      elements: [
+        {
+          name: 'any',
+        },
+      ],
+    });
+  });
+
+  describe('React types', () => {
+    function test(type, expected) {
+      const typePath = statement(`
+        var x: ${type} = 2;
+
+        type Props = { x: string };
+      `)
+        .get('declarations', 0)
+        .get('id')
+        .get('typeAnnotation')
+        .get('typeAnnotation');
+
+      expect(getTSType(typePath)).toEqual({
+        ...expected,
+        name: type.replace('.', '').replace(/<.+>/, ''),
+        raw: type,
+      });
+    }
+
+    const types = {
+      'React.Node': {},
+      'React.Key': {},
+      'React.ElementType': {},
+      'React.ChildrenArray<string>': { elements: [{ name: 'string' }] },
+      'React.Element<any>': { elements: [{ name: 'any' }] },
+      'React.Ref<typeof Component>': { elements: [{ name: 'Component' }] },
+      'React.ElementProps<Component>': { elements: [{ name: 'Component' }] },
+      'React.ElementRef<Component>': { elements: [{ name: 'Component' }] },
+      'React.ComponentType<Props>': {
+        elements: [
+          {
+            name: 'signature',
+            raw: '{ x: string }',
+            signature: {
+              properties: [
+                { key: 'x', value: { name: 'string', required: true } },
+              ],
+            },
+            type: 'object',
+          },
+        ],
+      },
+      'React.StatelessFunctionalComponent<Props2>': {
+        elements: [{ name: 'Props2' }],
+      },
+    };
+
+    Object.keys(types).forEach(type => {
+      it(type, () => test(type, types[type]));
+    });
+  });
+
+  it('resolves keyof to union', () => {
+    const typePath = statement(`
+      var x: keyof typeof CONTENTS = 2;
+      const CONTENTS = {
+        'apple': '🍎',
+        'banana': '🍌',
+      };
+    `)
+      .get('declarations', 0)
+      .get('id')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+
+    expect(getTSType(typePath)).toEqual({
+      name: 'union',
+      elements: [
+        { name: 'literal', value: "'apple'" },
+        { name: 'literal', value: "'banana'" },
+      ],
+      raw: 'keyof typeof CONTENTS',
+    });
+  });
+
+  it('resolves keyof with inline object to union', () => {
+    const typePath = statement(`
+      var x: keyof { apple: string, banana: string } = 2;
+    `)
+      .get('declarations', 0)
+      .get('id')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+
+    expect(getTSType(typePath)).toEqual({
+      name: 'union',
+      elements: [
+        { name: 'literal', value: 'apple' },
+        { name: 'literal', value: 'banana' },
+      ],
+      raw: 'keyof { apple: string, banana: string }',
+    });
+  });
+
+  it('handles multiple references to one type', () => {
+    const typePath = statement(`
+      let action: { a: Action, b: Action };
+      type Action = {};
+    `)
+      .get('declarations', 0)
+      .get('id')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+
+    expect(getTSType(typePath)).toEqual({
+      name: 'signature',
+      type: 'object',
+      signature: {
+        properties: [
+          {
+            key: 'a',
+            value: {
+              name: 'signature',
+              type: 'object',
+              required: true,
+              raw: '{}',
+              signature: { properties: [] },
+            },
+          },
+          {
+            key: 'b',
+            value: {
+              name: 'signature',
+              type: 'object',
+              required: true,
+              raw: '{}',
+              signature: { properties: [] },
+            },
+          },
+        ],
+      },
+      raw: '{ a: Action, b: Action }',
+    });
+  });
+
+  it('handles self-referencing type cycles', () => {
+    const typePath = statement(`
+      let action: Action;
+      type Action = { subAction: Action };
+    `)
+      .get('declarations', 0)
+      .get('id')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+
+    expect(getTSType(typePath)).toEqual({
+      name: 'signature',
+      type: 'object',
+      signature: {
+        properties: [
+          { key: 'subAction', value: { name: 'Action', required: true } },
+        ],
+      },
+      raw: '{ subAction: Action }',
+    });
+  });
+
+  it('handles long type cycles', () => {
+    const typePath = statement(`
+      let action: Action;
+      type Action = { subAction: SubAction };
+      type SubAction = { subAction: SubSubAction };
+      type SubSubAction = { subAction: SubSubSubAction };
+      type SubSubSubAction = { rootAction: Action };
+    `)
+      .get('declarations', 0)
+      .get('id')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+
+    expect(getTSType(typePath)).toEqual({
+      name: 'signature',
+      type: 'object',
+      signature: {
+        properties: [
+          {
+            key: 'subAction',
+            value: {
+              name: 'signature',
+              type: 'object',
+              required: true,
+              signature: {
+                properties: [
+                  {
+                    key: 'subAction',
+                    value: {
+                      name: 'signature',
+                      type: 'object',
+                      required: true,
+                      signature: {
+                        properties: [
+                          {
+                            key: 'subAction',
+                            value: {
+                              name: 'signature',
+                              type: 'object',
+                              required: true,
+                              signature: {
+                                properties: [
+                                  {
+                                    key: 'rootAction',
+                                    value: { name: 'Action', required: true },
+                                  },
+                                ],
+                              },
+                              raw: '{ rootAction: Action }',
+                            },
+                          },
+                        ],
+                      },
+                      raw: '{ subAction: SubSubSubAction }',
+                    },
+                  },
+                ],
+              },
+              raw: '{ subAction: SubSubAction }',
+            },
+          },
+        ],
+      },
+      raw: '{ subAction: SubAction }',
+    });
+  });
+});

--- a/src/utils/__tests__/getTSType-test.js
+++ b/src/utils/__tests__/getTSType-test.js
@@ -185,7 +185,9 @@ describe('getTSType', () => {
   });
 
   it('detects function signature type', () => {
-    const typePath = expression('x: (p1: number, p2: string) => boolean')
+    const typePath = expression(
+      'x: (p1: number, p2: string, ...rest: Array<string>) => boolean',
+    )
       .get('typeAnnotation')
       .get('typeAnnotation');
     expect(getTSType(typePath)).toEqual({
@@ -195,10 +197,19 @@ describe('getTSType', () => {
         arguments: [
           { name: 'p1', type: { name: 'number' } },
           { name: 'p2', type: { name: 'string' } },
+          {
+            name: 'rest',
+            rest: true,
+            type: {
+              name: 'Array',
+              elements: [{ name: 'string' }],
+              raw: 'Array<string>',
+            },
+          },
         ],
         return: { name: 'boolean' },
       },
-      raw: '(p1: number, p2: string) => boolean',
+      raw: '(p1: number, p2: string, ...rest: Array<string>) => boolean',
     });
   });
 

--- a/src/utils/__tests__/getTSType-test.js
+++ b/src/utils/__tests__/getTSType-test.js
@@ -373,6 +373,44 @@ describe('getTSType', () => {
     });
   });
 
+  it('handles generic types', () => {
+    const typePath = statement(`
+      var x: MyType<string> = {};
+
+      type MyType<T> = { a: T, b: Array<T> };
+    `)
+      .get('declarations', 0)
+      .get('id')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+
+    expect(getTSType(typePath)).toEqual({
+      name: 'signature',
+      type: 'object',
+      raw: '{ a: T, b: Array<T> }',
+      signature: {
+        properties: [
+          {
+            key: 'a',
+            value: {
+              name: 'string',
+              required: true,
+            },
+          },
+          {
+            key: 'b',
+            value: {
+              name: 'Array',
+              raw: 'Array<T>',
+              required: true,
+              elements: [{ name: 'string' }],
+            },
+          },
+        ],
+      },
+    });
+  });
+
   describe('React types', () => {
     function test(type, expected) {
       const typePath = statement(`

--- a/src/utils/__tests__/getTSType-test.js
+++ b/src/utils/__tests__/getTSType-test.js
@@ -213,6 +213,22 @@ describe('getTSType', () => {
     });
   });
 
+  it('detects function signature type with `this` parameter', () => {
+    const typePath = expression('x: (this: Foo, p1: number) => boolean')
+      .get('typeAnnotation')
+      .get('typeAnnotation');
+    expect(getTSType(typePath)).toEqual({
+      name: 'signature',
+      type: 'function',
+      signature: {
+        arguments: [{ name: 'p1', type: { name: 'number' } }],
+        this: { name: 'Foo' },
+        return: { name: 'boolean' },
+      },
+      raw: '(this: Foo, p1: number) => boolean',
+    });
+  });
+
   it('detects callable signature type', () => {
     const typePath = expression('x: { (str: string): string, token: string }')
       .get('typeAnnotation')

--- a/src/utils/__tests__/resolveExportDeclaration-test.js
+++ b/src/utils/__tests__/resolveExportDeclaration-test.js
@@ -53,7 +53,7 @@ describe('resolveExportDeclaration', () => {
   });
 
   it('resolves named exports', () => {
-    const exp = statement('export {foo, bar, baz}');
+    const exp = statement('export {foo, bar, baz}; var foo, bar, baz;');
     const resolved = resolveExportDeclaration(exp);
 
     const specifiers = exp.get('specifiers');

--- a/src/utils/getFlowType.js
+++ b/src/utils/getFlowType.js
@@ -266,13 +266,27 @@ function handleFunctionTypeAnnotation(
 
   path.get('params').each(param => {
     const typeAnnotation = getTypeAnnotation(param);
-    if (!typeAnnotation) return;
 
     type.signature.arguments.push({
       name: param.node.name ? param.node.name.name : '',
-      type: getFlowTypeWithResolvedTypes(typeAnnotation, typeParams),
+      type: typeAnnotation
+        ? getFlowTypeWithResolvedTypes(typeAnnotation, typeParams)
+        : null,
     });
   });
+
+  if (path.node.rest) {
+    const rest = path.get('rest');
+    const typeAnnotation = getTypeAnnotation(rest);
+
+    type.signature.arguments.push({
+      name: rest.node.name ? rest.node.name.name : '',
+      type: typeAnnotation
+        ? getFlowTypeWithResolvedTypes(typeAnnotation, typeParams)
+        : null,
+      rest: true,
+    });
+  }
 
   return type;
 }

--- a/src/utils/getFlowTypeFromReactComponent.js
+++ b/src/utils/getFlowTypeFromReactComponent.js
@@ -56,6 +56,18 @@ export function applyToFlowTypeProperties(
     path.get('properties').each(propertyPath => callback(propertyPath));
   } else if (path.node.members) {
     path.get('members').each(propertyPath => callback(propertyPath));
+  } else if (path.node.type === 'InterfaceDeclaration') {
+    if (path.node.extends) {
+      applyExtends(path, callback);
+    }
+
+    path.get('body', 'properties').each(propertyPath => callback(propertyPath));
+  } else if (path.node.type === 'TSInterfaceDeclaration') {
+    if (path.node.extends) {
+      applyExtends(path, callback);
+    }
+
+    path.get('body', 'body').each(propertyPath => callback(propertyPath));
   } else if (
     path.node.type === 'IntersectionTypeAnnotation' ||
     path.node.type === 'TSIntersectionType'
@@ -71,4 +83,13 @@ export function applyToFlowTypeProperties(
       applyToFlowTypeProperties(typePath, callback);
     }
   }
+}
+
+function applyExtends(path, callback) {
+  path.get('extends').each((extendsPath: NodePath) => {
+    const resolvedPath = resolveGenericTypeAnnotation(extendsPath);
+    if (resolvedPath) {
+      applyToFlowTypeProperties(resolvedPath, callback);
+    }
+  });
 }

--- a/src/utils/getFlowTypeFromReactComponent.js
+++ b/src/utils/getFlowTypeFromReactComponent.js
@@ -54,7 +54,12 @@ export function applyToFlowTypeProperties(
 ) {
   if (path.node.properties) {
     path.get('properties').each(propertyPath => callback(propertyPath));
-  } else if (path.node.type === 'IntersectionTypeAnnotation') {
+  } else if (path.node.members) {
+    path.get('members').each(propertyPath => callback(propertyPath));
+  } else if (
+    path.node.type === 'IntersectionTypeAnnotation' ||
+    path.node.type === 'TSIntersectionType'
+  ) {
     path
       .get('types')
       .each(typesPath => applyToFlowTypeProperties(typesPath, callback));

--- a/src/utils/getTSType.js
+++ b/src/utils/getTSType.js
@@ -1,0 +1,300 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+import getPropertyName from './getPropertyName';
+import printValue from './printValue';
+import recast from 'recast';
+import getTypeAnnotation from '../utils/getTypeAnnotation';
+import resolveToValue from '../utils/resolveToValue';
+import { resolveObjectToNameArray } from '../utils/resolveObjectKeysToArray';
+import type {
+  FlowTypeDescriptor,
+  FlowElementsType,
+  FlowFunctionSignatureType,
+  FlowObjectSignatureType,
+} from '../types';
+
+const {
+  types: { namedTypes: types },
+} = recast;
+
+const tsTypes = {
+  TSAnyKeyword: 'any',
+  TSBooleanKeyword: 'boolean',
+  TSUnknownKeyword: 'unknown',
+  TSNullKeyword: 'null',
+  TSUndefinedKeyword: 'undefined',
+  TSNumberKeyword: 'number',
+  TSStringKeyword: 'string',
+  TSSymbolKeyword: 'symbol',
+  TSThisType: 'this',
+  TSObjectKeyword: 'object',
+  TSVoidKeyword: 'void',
+};
+
+const namedTypes = {
+  TSArrayType: handleTSArrayType,
+  TSTypeReference: handleTSTypeReference,
+  TSTypeLiteral: handleTSTypeLiteral,
+  TSUnionType: handleTSUnionType,
+  TSFunctionType: handleTSFunctionType,
+  TSIntersectionType: handleTSIntersectionType,
+  TSTupleType: handleTSTupleType,
+  TSTypeQuery: handleTSTypeQuery,
+  TSTypeOperator: handleTSTypeOperator,
+};
+
+function handleTSArrayType(path: NodePath): FlowElementsType {
+  return {
+    name: 'Array',
+    elements: [getTSTypeWithResolvedTypes(path.get('elementType'))],
+    raw: printValue(path),
+  };
+}
+
+function handleTSTypeReference(path: NodePath): ?FlowTypeDescriptor {
+  let type: FlowTypeDescriptor;
+  if (types.TSQualifiedName.check(path.node.typeName)) {
+    const typeName = path.get('typeName');
+
+    if (typeName.node.left.name === 'React') {
+      type = {
+        name: `${typeName.node.left.name}${typeName.node.right.name}`,
+        raw: printValue(typeName),
+      };
+    } else {
+      type = { name: printValue(typeName).replace(/<.*>$/, '') };
+    }
+  } else {
+    type = { name: path.node.typeName.name };
+  }
+
+  if (path.node.typeParameters) {
+    const params = path.get('typeParameters').get('params');
+
+    type = {
+      ...type,
+      elements: params.map(param => getTSTypeWithResolvedTypes(param)),
+      raw: printValue(path),
+    };
+  } else {
+    const resolvedPath = resolveToValue(path.get('typeName'));
+    if (resolvedPath && resolvedPath.node.typeAnnotation) {
+      type = getTSTypeWithResolvedTypes(resolvedPath.get('typeAnnotation'));
+    }
+  }
+
+  return type;
+}
+
+function getTSTypeWithRequirements(path: NodePath): FlowTypeDescriptor {
+  const type = getTSTypeWithResolvedTypes(path);
+  type.required = !path.parentPath.node.optional;
+  return type;
+}
+
+function handleTSTypeLiteral(path: NodePath): FlowTypeDescriptor {
+  const type: FlowObjectSignatureType = {
+    name: 'signature',
+    type: 'object',
+    raw: printValue(path),
+    signature: { properties: [] },
+  };
+
+  path.get('members').each(param => {
+    if (
+      types.TSPropertySignature.check(param.node) ||
+      types.TSMethodSignature.check(param.node)
+    ) {
+      type.signature.properties.push({
+        key: getPropertyName(param),
+        value: getTSTypeWithRequirements(param.get('typeAnnotation')),
+      });
+    } else if (types.TSCallSignatureDeclaration.check(param.node)) {
+      type.signature.constructor = handleTSFunctionType(param);
+    } else if (types.TSIndexSignature.check(param.node)) {
+      type.signature.properties.push({
+        key: getTSTypeWithResolvedTypes(
+          param
+            .get('parameters')
+            .get(0)
+            .get('typeAnnotation'),
+        ),
+        value: getTSTypeWithRequirements(param.get('typeAnnotation')),
+      });
+    }
+  });
+
+  return type;
+}
+
+function handleTSUnionType(path: NodePath): FlowElementsType {
+  return {
+    name: 'union',
+    raw: printValue(path),
+    elements: path
+      .get('types')
+      .map(subType => getTSTypeWithResolvedTypes(subType)),
+  };
+}
+
+function handleTSIntersectionType(path: NodePath): FlowElementsType {
+  return {
+    name: 'intersection',
+    raw: printValue(path),
+    elements: path
+      .get('types')
+      .map(subType => getTSTypeWithResolvedTypes(subType)),
+  };
+}
+
+function handleTSFunctionType(path: NodePath): FlowFunctionSignatureType {
+  const type: FlowFunctionSignatureType = {
+    name: 'signature',
+    type: 'function',
+    raw: printValue(path),
+    signature: {
+      arguments: [],
+      return: getTSTypeWithResolvedTypes(path.get('typeAnnotation')),
+    },
+  };
+
+  path.get('parameters').each(param => {
+    const typeAnnotation = getTypeAnnotation(param);
+    if (!typeAnnotation) return;
+
+    type.signature.arguments.push({
+      name: param.node.name || '',
+      type: getTSTypeWithResolvedTypes(typeAnnotation),
+    });
+  });
+
+  return type;
+}
+
+function handleTSTupleType(path: NodePath): FlowElementsType {
+  const type: FlowElementsType = {
+    name: 'tuple',
+    raw: printValue(path),
+    elements: [],
+  };
+
+  path.get('elementTypes').each(param => {
+    type.elements.push(getTSTypeWithResolvedTypes(param));
+  });
+
+  return type;
+}
+
+function handleTSTypeQuery(path: NodePath): FlowTypeDescriptor {
+  const resolvedPath = resolveToValue(path.get('exprName'));
+  if (resolvedPath && resolvedPath.node.typeAnnotation) {
+    return getTSTypeWithResolvedTypes(resolvedPath.get('typeAnnotation'));
+  }
+
+  return { name: path.node.exprName.name };
+}
+
+function handleTSTypeOperator(path: NodePath): FlowTypeDescriptor {
+  if (path.node.operator !== 'keyof') {
+    return null;
+  }
+
+  let value = path.get('typeAnnotation');
+  if (types.TSTypeQuery.check(value.node)) {
+    value = value.get('exprName');
+  } else if (value.node.id) {
+    value = value.get('id');
+  }
+
+  const resolvedPath = resolveToValue(value);
+  if (
+    resolvedPath &&
+    (types.ObjectExpression.check(resolvedPath.node) ||
+      types.TSTypeLiteral.check(resolvedPath.node))
+  ) {
+    const keys = resolveObjectToNameArray(resolvedPath, true);
+
+    if (keys) {
+      return {
+        name: 'union',
+        raw: printValue(path),
+        elements: keys.map(key => ({ name: 'literal', value: key })),
+      };
+    }
+  }
+}
+
+let visitedTypes = {};
+
+function getTSTypeWithResolvedTypes(path: NodePath): FlowTypeDescriptor {
+  if (types.TSTypeAnnotation.check(path.node)) {
+    path = path.get('typeAnnotation');
+  }
+
+  const node = path.node;
+  let type: ?FlowTypeDescriptor;
+  const isTypeAlias = types.TSTypeAliasDeclaration.check(path.parentPath.node);
+
+  // When we see a typealias mark it as visited so that the next
+  // call of this function does not run into an endless loop
+  if (isTypeAlias) {
+    if (visitedTypes[path.parentPath.node.id.name] === true) {
+      // if we are currently visiting this node then just return the name
+      // as we are starting to endless loop
+      return { name: path.parentPath.node.id.name };
+    } else if (typeof visitedTypes[path.parentPath.node.id.name] === 'object') {
+      // if we already resolved the type simple return it
+      return visitedTypes[path.parentPath.node.id.name];
+    }
+    // mark the type as visited
+    visitedTypes[path.parentPath.node.id.name] = true;
+  }
+
+  if (types.TSType.check(node)) {
+    if (node.type in tsTypes) {
+      type = { name: tsTypes[node.type] };
+    } else if (types.TSLiteralType.check(node)) {
+      type = {
+        name: 'literal',
+        value: node.literal.raw || `${node.literal.value}`,
+      };
+    } else if (node.type in namedTypes) {
+      type = namedTypes[node.type](path);
+    }
+  }
+
+  if (!type) {
+    type = { name: 'unknown' };
+  }
+
+  if (isTypeAlias) {
+    // mark the type as unvisited so that further calls can resolve the type again
+    visitedTypes[path.parentPath.node.id.name] = type;
+  }
+
+  return type;
+}
+
+/**
+ * Tries to identify the flow type by inspecting the path for known
+ * flow type names. This method doesn't check whether the found type is actually
+ * existing. It simply assumes that a match is always valid.
+ *
+ * If there is no match, "unknown" is returned.
+ */
+export default function getTSType(path: NodePath): FlowTypeDescriptor {
+  // Empty visited types before an after run
+  // Before: in case the detection threw and we rerun again
+  // After: cleanup memory after we are done here
+  visitedTypes = {};
+  const type = getTSTypeWithResolvedTypes(path);
+  visitedTypes = {};
+
+  return type;
+}

--- a/src/utils/getTSType.js
+++ b/src/utils/getTSType.js
@@ -236,6 +236,11 @@ function handleTSFunctionType(
         : null,
     };
 
+    if (param.node.name === 'this') {
+      type.signature.this = arg.type;
+      return;
+    }
+
     if (param.node.type === 'RestElement') {
       arg.name = param.node.argument.name;
       arg.rest = true;

--- a/src/utils/getTSType.js
+++ b/src/utils/getTSType.js
@@ -19,6 +19,7 @@ import type {
   FlowTypeDescriptor,
   FlowElementsType,
   FlowFunctionSignatureType,
+  FlowFunctionArgumentType,
   FlowObjectSignatureType,
 } from '../types';
 
@@ -30,6 +31,7 @@ const tsTypes = {
   TSAnyKeyword: 'any',
   TSBooleanKeyword: 'boolean',
   TSUnknownKeyword: 'unknown',
+  TSNeverKeyword: 'never',
   TSNullKeyword: 'null',
   TSUndefinedKeyword: 'undefined',
   TSNumberKeyword: 'number',
@@ -227,12 +229,19 @@ function handleTSFunctionType(
 
   path.get('parameters').each(param => {
     const typeAnnotation = getTypeAnnotation(param);
-    if (!typeAnnotation) return;
-
-    type.signature.arguments.push({
+    const arg: FlowFunctionArgumentType = {
       name: param.node.name || '',
-      type: getTSTypeWithResolvedTypes(typeAnnotation, typeParams),
-    });
+      type: typeAnnotation
+        ? getTSTypeWithResolvedTypes(typeAnnotation, typeParams)
+        : null,
+    };
+
+    if (param.node.type === 'RestElement') {
+      arg.name = param.node.argument.name;
+      arg.rest = true;
+    }
+
+    type.signature.arguments.push(arg);
   });
 
   return type;

--- a/src/utils/getTypeAnnotation.js
+++ b/src/utils/getTypeAnnotation.js
@@ -28,7 +28,8 @@ export default function getTypeAnnotation(path: NodePath): ?NodePath {
     resultPath = resultPath.get('typeAnnotation');
   } while (
     hasTypeAnnotation(resultPath) &&
-    !types.FlowType.check(resultPath.node)
+    !types.FlowType.check(resultPath.node) &&
+    !types.TSType.check(resultPath.node)
   );
 
   return resultPath;

--- a/src/utils/getTypeParameters.js
+++ b/src/utils/getTypeParameters.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import resolveGenericTypeAnnotation from '../utils/resolveGenericTypeAnnotation';
+
+export type TypeParameters = {
+  [string]: NodePath,
+};
+
+export default function getTypeParameters(
+  declaration: NodePath,
+  instantiation: NodePath,
+  inputParams: ?TypeParameters,
+) {
+  const params = {};
+
+  let i = 0;
+  declaration.get('params').each((paramPath: NodePath) => {
+    const key = paramPath.node.name;
+    const defaultTypePath = paramPath.node.default
+      ? paramPath.get('default')
+      : null;
+    const typePath =
+      i < instantiation.node.params.length
+        ? instantiation.get('params', i++)
+        : defaultTypePath;
+
+    if (typePath) {
+      let resolvedTypePath = resolveGenericTypeAnnotation(typePath) || typePath;
+      const typeName =
+        resolvedTypePath.node.typeName || resolvedTypePath.node.id;
+      if (typeName && inputParams && inputParams[typeName.name]) {
+        resolvedTypePath = inputParams[typeName.name];
+      }
+
+      params[key] = resolvedTypePath;
+    }
+  });
+
+  return params;
+}

--- a/src/utils/getTypeParameters.js
+++ b/src/utils/getTypeParameters.js
@@ -17,8 +17,9 @@ export default function getTypeParameters(
   declaration: NodePath,
   instantiation: NodePath,
   inputParams: ?TypeParameters,
-) {
+): TypeParameters {
   const params = {};
+  const numInstantiationParams = instantiation.node.params.length;
 
   let i = 0;
   declaration.get('params').each((paramPath: NodePath) => {
@@ -27,7 +28,7 @@ export default function getTypeParameters(
       ? paramPath.get('default')
       : null;
     const typePath =
-      i < instantiation.node.params.length
+      i < numInstantiationParams
         ? instantiation.get('params', i++)
         : defaultTypePath;
 

--- a/src/utils/resolveGenericTypeAnnotation.js
+++ b/src/utils/resolveGenericTypeAnnotation.js
@@ -26,6 +26,13 @@ function tryResolveGenericTypeAnnotation(path: NodePath): ?NodePath {
     }
 
     return tryResolveGenericTypeAnnotation(typePath.get('right'));
+  } else if (types.TSTypeReference.check(typePath.node)) {
+    typePath = resolveToValue(typePath.get('typeName'));
+    if (isUnreachableFlowType(typePath)) {
+      return;
+    }
+
+    return tryResolveGenericTypeAnnotation(typePath.get('typeAnnotation'));
   }
 
   return typePath;

--- a/src/utils/resolveToValue.js
+++ b/src/utils/resolveToValue.js
@@ -51,7 +51,8 @@ function findScopePath(paths: Array<NodePath>, path: NodePath): ?NodePath {
     types.ImportSpecifier.check(parentPath.node) ||
     types.ImportNamespaceSpecifier.check(parentPath.node) ||
     types.VariableDeclarator.check(parentPath.node) ||
-    types.TypeAlias.check(parentPath.node)
+    types.TypeAlias.check(parentPath.node) ||
+    types.TSTypeAliasDeclaration.check(parentPath.node)
   ) {
     resultPath = parentPath;
   } else if (types.Property.check(parentPath.node)) {

--- a/src/utils/resolveToValue.js
+++ b/src/utils/resolveToValue.js
@@ -52,7 +52,9 @@ function findScopePath(paths: Array<NodePath>, path: NodePath): ?NodePath {
     types.ImportNamespaceSpecifier.check(parentPath.node) ||
     types.VariableDeclarator.check(parentPath.node) ||
     types.TypeAlias.check(parentPath.node) ||
-    types.TSTypeAliasDeclaration.check(parentPath.node)
+    types.InterfaceDeclaration.check(parentPath.node) ||
+    types.TSTypeAliasDeclaration.check(parentPath.node) ||
+    types.TSInterfaceDeclaration.check(parentPath.node)
   ) {
     resultPath = parentPath;
   } else if (types.Property.check(parentPath.node)) {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -21,12 +21,12 @@ export function parse(src, recast = _recast, options = {}) {
   );
 }
 
-export function statement(src, recast = _recast) {
-  return parse(src, recast).get('body', 0);
+export function statement(src, recast = _recast, options) {
+  return parse(src, recast, options).get('body', 0);
 }
 
-export function expression(src, recast = _recast) {
-  return statement('(' + src + ')', recast).get('expression');
+export function expression(src, recast = _recast, options) {
+  return statement('(' + src + ')', recast, options).get('expression');
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,7 +26,7 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/core@^7.0.0", "@babel/core@^7.1.0":
+"@babel/core@^7.1.0":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.2.2.tgz#07adba6dde27bb5ad8d8672f15fde3e08184a687"
   integrity sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==
@@ -46,6 +46,26 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.4.tgz#84055750b05fcd50f9915a826b44fa347a825250"
+  integrity sha512-lQgGX3FPRgbz2SKmhMtYgJvVzGZrmjaF4apZ2bLwofAKiSjxU0drPh4S/VasyYXwaTs+A1gvQ45BN8SQJzHsQQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.4.4"
+    "@babel/helpers" "^7.4.4"
+    "@babel/parser" "^7.4.4"
+    "@babel/template" "^7.4.4"
+    "@babel/traverse" "^7.4.4"
+    "@babel/types" "^7.4.4"
+    convert-source-map "^1.1.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.11"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.0.0", "@babel/generator@^7.2.2":
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.3.2.tgz#fff31a7b2f2f3dad23ef8e01be45b0d5c2fc0132"
@@ -54,6 +74,17 @@
     "@babel/types" "^7.3.2"
     jsesc "^2.5.1"
     lodash "^4.17.10"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/generator@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.4.4.tgz#174a215eb843fc392c7edcaabeaa873de6e8f041"
+  integrity sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==
+  dependencies:
+    "@babel/types" "^7.4.4"
+    jsesc "^2.5.1"
+    lodash "^4.17.11"
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
@@ -202,6 +233,13 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
+"@babel/helper-split-export-declaration@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz#ff94894a340be78f53f06af038b205c49d993677"
+  integrity sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==
+  dependencies:
+    "@babel/types" "^7.4.4"
+
 "@babel/helper-wrap-function@^7.1.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz#c4e0012445769e2815b55296ead43a958549f6fa"
@@ -221,6 +259,15 @@
     "@babel/traverse" "^7.1.5"
     "@babel/types" "^7.3.0"
 
+"@babel/helpers@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.4.4.tgz#868b0ef59c1dd4e78744562d5ce1b59c89f2f2a5"
+  integrity sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==
+  dependencies:
+    "@babel/template" "^7.4.4"
+    "@babel/traverse" "^7.4.4"
+    "@babel/types" "^7.4.4"
+
 "@babel/highlight@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
@@ -234,6 +281,11 @@
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.2.tgz#95cdeddfc3992a6ca2a1315191c1679ca32c55cd"
   integrity sha512-QzNUC2RO1gadg+fs21fi0Uu0OuGNzRKEmgCxoLNzbCdoprLwjfmZwzUrpUNfJPaVRwBpDY47A17yYEGWyRelnQ==
+
+"@babel/parser@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.4.tgz#5977129431b8fe33471730d255ce8654ae1250b6"
+  integrity sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==
 
 "@babel/plugin-proposal-async-generator-functions@^7.2.0":
   version "7.2.0"
@@ -625,6 +677,15 @@
     "@babel/parser" "^7.2.2"
     "@babel/types" "^7.2.2"
 
+"@babel/template@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
+  integrity sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.4.4"
+    "@babel/types" "^7.4.4"
+
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.1.5", "@babel/traverse@^7.2.2", "@babel/traverse@^7.2.3":
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.2.3.tgz#7ff50cefa9c7c0bd2d81231fdac122f3957748d8"
@@ -640,6 +701,21 @@
     globals "^11.1.0"
     lodash "^4.17.10"
 
+"@babel/traverse@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.4.tgz#0776f038f6d78361860b6823887d4f3937133fe8"
+  integrity sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.4.4"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.4.4"
+    "@babel/types" "^7.4.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.11"
+
 "@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.2.2", "@babel/types@^7.3.0", "@babel/types@^7.3.2":
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.3.2.tgz#424f5be4be633fff33fb83ab8d67e4a8290f5a2f"
@@ -647,6 +723,15 @@
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.10"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.4.tgz#8db9e9a629bb7c29370009b4b779ed93fe57d5f0"
+  integrity sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
 abab@^2.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -806,10 +806,10 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-ast-types@0.12.2:
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.12.2.tgz#341656049ee328ac03fc805c156b49ebab1e4462"
-  integrity sha512-8c83xDLJM/dLDyXNLiR6afRRm4dPKN6KAnKqytRK3DBJul9lA+atxdQkNDkSVPdTqea5HiRq3lnnOIZ0MBpvdg==
+ast-types@0.12.4:
+  version "0.12.4"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.12.4.tgz#71ce6383800f24efc9a1a3308f3a6e420a0974d1"
+  integrity sha512-ky/YVYCbtVAS8TdMIaTiPFHwEpRB5z1hctepJplTr3UW5q8TDrpIMCILyk8pmLxGtn2KCtC/lSn7zOsaI7nzDw==
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -3582,12 +3582,12 @@ realpath-native@^1.0.0, realpath-native@^1.0.2:
   dependencies:
     util.promisify "^1.0.0"
 
-recast@^0.17.3:
-  version "0.17.3"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.17.3.tgz#f49a9c9a64c59b55f6c93b5a53e3cffd7a13354d"
-  integrity sha512-NwQguXPwHqaVb6M7tsY11+8RDoAKHGRdymPGDxHJrsxOlNADQh0b08uz/MgYp1R1wmHuSBK4A4I5Oq+cE1J40g==
+recast@^0.17.6:
+  version "0.17.6"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.17.6.tgz#64ae98d0d2dfb10ff92ff5fb9ffb7371823b69fa"
+  integrity sha512-yoQRMRrK1lszNtbkGyM4kN45AwylV5hMiuEveUBlxytUViWevjvX6w+tzJt1LH4cfUhWt4NZvy3ThIhu6+m5wQ==
   dependencies:
-    ast-types "0.12.2"
+    ast-types "0.12.4"
     esprima "~4.0.0"
     private "^0.1.8"
     source-map "~0.6.1"


### PR DESCRIPTION
Closes #325.
Depends on https://github.com/benjamn/ast-types/pull/330

This adds TypeScript support to react-docgen. It automatically replaces the flow plugin with the typescript plugin in babel-parser when a `.ts` or `.tsx` file is seen.

The output follows the existing flow output format since TypeScript types are quite similar to Flow. The implementation follows the existing flow implementation quite closely as well - a new `getTSType` file is added similar to the `getFlowType` one, and the surrounding code is updated to also handle TypeScript annotations in addition to Flow.

This brings up several questions about API and code organization.

1. Do we want to change the output format key from `flowType` to something more generic, add an additional `tsType` key, or just leave it as is?
2. Internally, do we want to leave the files/function names that now handle both flow and typescript with flow in the name, or change them to be more generic as well?

A few things left to do on this:

- [x] Support interfaces in addition to type aliases. This is also not currently the case for Flow, however...
- [x] Ensure that all TypeScript types are handled
- [x] Handle method documentation for TypeScript
- [x] Decide on questions above