### PR TITLE
feat(defaultPropsHandler): Fully support forwardRef

### DIFF
--- a/src/handlers/__tests__/__snapshots__/defaultPropsHandler-test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/defaultPropsHandler-test.js.snap
@@ -226,6 +226,28 @@ Object {
 }
 `;
 
+exports[`defaultPropsHandler forwardRef resolves default props in the parameters 1`] = `
+Object {
+  "foo": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "'bar'",
+    },
+  },
+}
+`;
+
+exports[`defaultPropsHandler forwardRef resolves defaultProps 1`] = `
+Object {
+  "foo": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "'baz'",
+    },
+  },
+}
+`;
+
 exports[`defaultPropsHandler should only consider Property nodes, not e.g. spread properties 1`] = `
 Object {
   "bar": Object {

--- a/src/handlers/__tests__/defaultPropsHandler-test.js
+++ b/src/handlers/__tests__/defaultPropsHandler-test.js
@@ -219,4 +219,28 @@ describe('defaultPropsHandler', () => {
       expect(documentation.descriptors).toMatchSnapshot();
     });
   });
+
+  describe('forwardRef', () => {
+    it('resolves default props in the parameters', () => {
+      const src = `
+        import React from 'react';
+        React.forwardRef(({ foo = 'bar' }, ref) => <div ref={ref}>{foo}</div>);
+      `;
+      defaultPropsHandler(
+        documentation,
+        parse(src).get('body', 1, 'expression'),
+      );
+      expect(documentation.descriptors).toMatchSnapshot();
+    });
+
+    it('resolves defaultProps', () => {
+      const src = `
+        import React from 'react';
+        const Component = React.forwardRef(({ foo }, ref) => <div ref={ref}>{foo}</div>);
+        Component.defaultProps = { foo: 'baz' };
+      `;
+      defaultPropsHandler(documentation, parse(src).get('body', 1));
+      expect(documentation.descriptors).toMatchSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
In `React.forwardRef(({ foo = 'bar' }, ref) => <div ref={ref}>{foo}</div>)` the default props handler would not detect that `foo` had a default value.

I was curious if #343  would've fixed this as well but this is not the case.