### PR TITLE
Support for importing types

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "commander": "^2.19.0",
     "doctrine": "^3.0.0",
     "node-dir": "^0.1.10",
-    "strip-indent": "^3.0.0",
-    "resolve": "^1.10.1"
+    "resolve": "^1.10.1",
+    "strip-indent": "^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -80,5 +80,8 @@
       "src"
     ],
     "testRegex": "/__tests__/.*-test\\.js$"
+  },
+  "browser": {
+    "./dist/utils/resolveImportedValue.js": "./dist/utils/resolveImportedValue.browser.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "commander": "^2.19.0",
     "doctrine": "^3.0.0",
     "node-dir": "^0.1.10",
-    "strip-indent": "^3.0.0"
+    "strip-indent": "^3.0.0",
+    "resolve": "^1.10.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -1633,3 +1633,26 @@ Object {
   },
 }
 `;
+
+exports[`main fixtures processes component "component_36.js" without errors 1`] = `
+Object {
+  "description": "",
+  "displayName": "SuperDuperCustomButton",
+  "methods": Array [],
+  "props": Object {
+    "size": Object {
+      "defaultValue": Object {
+        "computed": true,
+        "value": "Sizes.EXTRA_LARGE",
+      },
+      "description": "",
+      "required": false,
+      "type": Object {
+        "computed": true,
+        "name": "enum",
+        "value": "Object.values(Sizes)",
+      },
+    },
+  },
+}
+`;

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -1562,3 +1562,34 @@ Object {
   },
 }
 `;
+
+exports[`main fixtures processes component "component_33.js" without errors 1`] = `
+Object {
+  "description": "",
+  "displayName": "SuperDuperCustomButton",
+  "methods": Array [],
+  "props": Object {
+    "children": Object {
+      "description": "",
+      "required": true,
+      "type": Object {
+        "name": "string",
+      },
+    },
+    "onClick": Object {
+      "description": "",
+      "required": false,
+      "type": Object {
+        "name": "func",
+      },
+    },
+    "style": Object {
+      "description": "",
+      "required": false,
+      "type": Object {
+        "name": "object",
+      },
+    },
+  },
+}
+`;

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -1421,3 +1421,144 @@ Object {
   },
 }
 `;
+
+exports[`main fixtures processes component "component_28.tsx" without errors 1`] = `
+Object {
+  "description": "This is a typescript component with imported prop types",
+  "displayName": "ImportedComponent",
+  "methods": Array [],
+  "props": Object {
+    "foo": Object {
+      "description": "",
+      "required": true,
+      "tsType": Object {
+        "name": "string",
+      },
+    },
+  },
+}
+`;
+
+exports[`main fixtures processes component "component_29.tsx" without errors 1`] = `
+Object {
+  "description": "This is a typescript component with imported prop types",
+  "displayName": "ImportedExtendedComponent",
+  "methods": Array [],
+  "props": Object {
+    "bar": Object {
+      "description": "",
+      "required": true,
+      "tsType": Object {
+        "name": "number",
+      },
+    },
+    "foo": Object {
+      "description": "",
+      "required": true,
+      "tsType": Object {
+        "name": "string",
+      },
+    },
+  },
+}
+`;
+
+exports[`main fixtures processes component "component_30.js" without errors 1`] = `
+Object {
+  "description": "",
+  "displayName": "CustomButton",
+  "methods": Array [],
+  "props": Object {
+    "children": Object {
+      "description": "",
+      "required": true,
+      "type": Object {
+        "name": "string",
+      },
+    },
+    "color": Object {
+      "description": "",
+      "required": false,
+      "type": Object {
+        "name": "string",
+      },
+    },
+    "onClick": Object {
+      "description": "",
+      "required": false,
+      "type": Object {
+        "name": "func",
+      },
+    },
+    "style": Object {
+      "description": "",
+      "required": false,
+      "type": Object {
+        "name": "object",
+      },
+    },
+  },
+}
+`;
+
+exports[`main fixtures processes component "component_31.js" without errors 1`] = `
+Object {
+  "description": "",
+  "displayName": "SuperCustomButton",
+  "methods": Array [],
+  "props": Object {
+    "children": Object {
+      "description": "",
+      "required": true,
+      "type": Object {
+        "name": "string",
+      },
+    },
+    "onClick": Object {
+      "description": "",
+      "required": false,
+      "type": Object {
+        "name": "func",
+      },
+    },
+    "style": Object {
+      "description": "",
+      "required": false,
+      "type": Object {
+        "name": "object",
+      },
+    },
+  },
+}
+`;
+
+exports[`main fixtures processes component "component_32.js" without errors 1`] = `
+Object {
+  "description": "",
+  "displayName": "SuperDuperCustomButton",
+  "methods": Array [],
+  "props": Object {
+    "children": Object {
+      "description": "",
+      "required": true,
+      "type": Object {
+        "name": "string",
+      },
+    },
+    "onClick": Object {
+      "description": "",
+      "required": false,
+      "type": Object {
+        "name": "func",
+      },
+    },
+    "style": Object {
+      "description": "",
+      "required": false,
+      "type": Object {
+        "name": "object",
+      },
+    },
+  },
+}
+`;

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -1593,3 +1593,34 @@ Object {
   },
 }
 `;
+
+exports[`main fixtures processes component "component_34.js" without errors 1`] = `
+Object {
+  "description": "",
+  "displayName": "SuperDuperCustomButton",
+  "methods": Array [],
+  "props": Object {
+    "children": Object {
+      "description": "",
+      "required": true,
+      "type": Object {
+        "name": "string",
+      },
+    },
+    "onClick": Object {
+      "description": "",
+      "required": false,
+      "type": Object {
+        "name": "func",
+      },
+    },
+    "style": Object {
+      "description": "",
+      "required": false,
+      "type": Object {
+        "name": "object",
+      },
+    },
+  },
+}
+`;

--- a/src/__tests__/fixtures/component_27.tsx
+++ b/src/__tests__/fixtures/component_27.tsx
@@ -8,7 +8,7 @@
 
 import React, { Component } from 'react';
 
-interface Props {
+export interface Props {
   foo: string
 }
 

--- a/src/__tests__/fixtures/component_28.tsx
+++ b/src/__tests__/fixtures/component_28.tsx
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React, { Component } from 'react';
+import { Props as ImportedProps } from './component_27';
+
+export default interface ExtendedProps extends ImportedProps {
+  bar: number
+}
+
+/**
+ * This is a typescript component with imported prop types
+ */
+export function ImportedComponent(props: ImportedProps) {
+  return <h1>Hello world</h1>;
+}

--- a/src/__tests__/fixtures/component_29.tsx
+++ b/src/__tests__/fixtures/component_29.tsx
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import React, { Component } from 'react';
+import ExtendedProps from './component_28';
+
+/**
+ * This is a typescript component with imported prop types
+ */
+export function ImportedExtendedComponent(props: ExtendedProps) {
+  return <h1>Hello world</h1>;
+}

--- a/src/__tests__/fixtures/component_30.js
+++ b/src/__tests__/fixtures/component_30.js
@@ -1,0 +1,13 @@
+import Button from './component_6';
+import PropTypes from 'prop-types';
+
+export function CustomButton({color, ...otherProps}) {
+  return <Button {...otherProps} style={{color}} />;
+}
+
+CustomButton.propTypes = {
+  ...Button.propTypes,
+  color: PropTypes.string
+};
+
+export const sharedProps = Button.propTypes;

--- a/src/__tests__/fixtures/component_31.js
+++ b/src/__tests__/fixtures/component_31.js
@@ -1,0 +1,9 @@
+import {CustomButton, sharedProps} from './component_30';
+import PropTypes from 'prop-types';
+
+export function SuperCustomButton({color, ...otherProps}) {
+  return <CustomButton {...otherProps} style={{color}} />;
+}
+
+SuperCustomButton.propTypes = sharedProps;
+export {sharedProps};

--- a/src/__tests__/fixtures/component_31.js
+++ b/src/__tests__/fixtures/component_31.js
@@ -7,3 +7,4 @@ export function SuperCustomButton({color, ...otherProps}) {
 
 SuperCustomButton.propTypes = sharedProps;
 export {sharedProps};
+export * from './component_32';

--- a/src/__tests__/fixtures/component_32.js
+++ b/src/__tests__/fixtures/component_32.js
@@ -6,3 +6,4 @@ export function SuperDuperCustomButton({color, ...otherProps}) {
 }
 
 SuperDuperCustomButton.propTypes = sharedProps;
+export * from './component_31';

--- a/src/__tests__/fixtures/component_32.js
+++ b/src/__tests__/fixtures/component_32.js
@@ -1,0 +1,8 @@
+import {SuperCustomButton, sharedProps} from './component_31';
+import PropTypes from 'prop-types';
+
+export function SuperDuperCustomButton({color, ...otherProps}) {
+  return <SuperCustomButton {...otherProps} style={{color}} />;
+}
+
+SuperDuperCustomButton.propTypes = sharedProps;

--- a/src/__tests__/fixtures/component_33.js
+++ b/src/__tests__/fixtures/component_33.js
@@ -1,4 +1,4 @@
-import * as C31 from './component_31';
+import * as C31 from './component_32';
 import PropTypes from 'prop-types';
 
 export function SuperDuperCustomButton({color, ...otherProps}) {

--- a/src/__tests__/fixtures/component_33.js
+++ b/src/__tests__/fixtures/component_33.js
@@ -1,0 +1,8 @@
+import * as C31 from './component_31';
+import PropTypes from 'prop-types';
+
+export function SuperDuperCustomButton({color, ...otherProps}) {
+  return <C31.SuperCustomButton {...otherProps} style={{color}} />;
+}
+
+SuperDuperCustomButton.propTypes = C31.sharedProps;

--- a/src/__tests__/fixtures/component_33.js
+++ b/src/__tests__/fixtures/component_33.js
@@ -6,3 +6,4 @@ export function SuperDuperCustomButton({color, ...otherProps}) {
 }
 
 SuperDuperCustomButton.propTypes = C31.sharedProps;
+export {SuperCustomButton} from './component_32';

--- a/src/__tests__/fixtures/component_34.js
+++ b/src/__tests__/fixtures/component_34.js
@@ -1,0 +1,8 @@
+import {SuperCustomButton} from './component_33';
+import PropTypes from 'prop-types';
+
+export function SuperDuperCustomButton({color, ...otherProps}) {
+  return <SuperCustomButton {...otherProps} style={{color}} />;
+}
+
+SuperDuperCustomButton.propTypes = SuperCustomButton.propTypes;

--- a/src/__tests__/fixtures/component_36.js
+++ b/src/__tests__/fixtures/component_36.js
@@ -1,0 +1,16 @@
+import { Sizes } from '../common';
+import T from 'prop-types';
+
+function SuperDuperCustomButton() {
+  return <div />;
+}
+
+SuperDuperCustomButton.defaultProps = {
+  size: Sizes.EXTRA_LARGE,
+};
+
+SuperDuperCustomButton.propTypes = {
+  size: T.oneOf(Object.values(Sizes)),
+};
+
+export default SuperDuperCustomButton;

--- a/src/babelParser.js
+++ b/src/babelParser.js
@@ -100,13 +100,17 @@ function buildOptions(
 export default function buildParse(options?: Options = {}): Parser {
   const { parserOptions, ...babelOptions } = options;
   const parserOpts = buildOptions(parserOptions, babelOptions);
+  const opts = {
+    parserOpts,
+    ...babelOptions,
+  };
 
   return {
     parse(src: string): ASTNode {
-      return babel.parseSync(src, {
-        parserOpts,
-        ...babelOptions,
-      });
+      const ast = babel.parseSync(src, opts);
+      // Attach options to the Program node, for use when processing imports.
+      ast.program.options = options;
+      return ast;
     },
   };
 }

--- a/src/handlers/__tests__/propDocblockHandler-test.js
+++ b/src/handlers/__tests__/propDocblockHandler-test.js
@@ -128,7 +128,7 @@ describe('propDocBlockHandler', () => {
       const definition = parse(
         getSrc(
           `{
-          ...Foo.propTypes,
+          ...Bar.propTypes,
           /**
            * Foo comment
            */

--- a/src/utils/getMemberValuePath.js
+++ b/src/utils/getMemberValuePath.js
@@ -37,7 +37,7 @@ const LOOKUP_METHOD = {
   [t.ClassExpression.name]: getClassMemberValuePath,
 };
 
-export function isSupportedDefinitionType({ node }) {
+export function isSupportedDefinitionType({ node }: NodePath) {
   return (
     t.ObjectExpression.check(node) ||
     t.ClassDeclaration.check(node) ||

--- a/src/utils/getMemberValuePath.js
+++ b/src/utils/getMemberValuePath.js
@@ -37,7 +37,7 @@ const LOOKUP_METHOD = {
   [t.ClassExpression.name]: getClassMemberValuePath,
 };
 
-function isSupportedDefinitionType({ node }) {
+export function isSupportedDefinitionType({ node }) {
   return (
     t.ObjectExpression.check(node) ||
     t.ClassDeclaration.check(node) ||

--- a/src/utils/isReactComponentClass.js
+++ b/src/utils/isReactComponentClass.js
@@ -64,7 +64,7 @@ export default function isReactComponentClass(path: NodePath): boolean {
   if (!node.superClass) {
     return false;
   }
-  const superClass = resolveToValue(path.get('superClass'));
+  const superClass = resolveToValue(path.get('superClass'), false);
   if (!match(superClass.node, { property: { name: 'Component' } })) {
     return false;
   }

--- a/src/utils/resolveImportedValue.browser.js
+++ b/src/utils/resolveImportedValue.browser.js
@@ -1,0 +1,4 @@
+export default function resolveImportedValue() {
+  // The browser build does not support importing due to the lack of fs access.
+  return null;
+}

--- a/src/utils/resolveImportedValue.js
+++ b/src/utils/resolveImportedValue.js
@@ -17,8 +17,6 @@ import fs from 'fs';
 const { namedTypes: t, NodePath } = types;
 
 export default function resolveImportedValue(path: NodePath, name: string) {
-  t.ImportDeclaration.assert(path.node);
-
   // Bail if no filename was provided for the current source file.
   // Also never traverse into react itself.
   const source = path.node.source.value;
@@ -101,7 +99,14 @@ function findExportedValue(ast, name) {
 
       return false;
     },
-    // TODO: visitExportAllDeclaration
+    visitExportAllDeclaration(path: NodePath) {
+      const resolvedPath = resolveImportedValue(path, name);
+      if (resolvedPath) {
+        resultPath = resolvedPath;
+      }
+
+      return false;
+    }
   });
 
   return resultPath;

--- a/src/utils/resolveImportedValue.js
+++ b/src/utils/resolveImportedValue.js
@@ -16,7 +16,11 @@ import fs from 'fs';
 
 const { namedTypes: t, NodePath } = types;
 
-export default function resolveImportedValue(path: NodePath, name: string, seen: Set<string> = new Set()) {
+export default function resolveImportedValue(
+  path: NodePath,
+  name: string,
+  seen: Set<string> = new Set(),
+) {
   // Bail if no filename was provided for the current source file.
   // Also never traverse into react itself.
   const source = path.node.source.value;
@@ -118,7 +122,7 @@ function findExportedValue(ast, name, seen) {
       }
 
       return false;
-    }
+    },
   });
 
   return resultPath;

--- a/src/utils/resolveImportedValue.js
+++ b/src/utils/resolveImportedValue.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import types from 'ast-types';
+import { traverseShallow } from './traverse';
+import resolve from 'resolve';
+import { dirname } from 'path';
+import buildParser, { type Options } from '../babelParser';
+import fs from 'fs';
+
+const { namedTypes: t, NodePath } = types;
+
+export default function resolveImportedValue(path: NodePath, name: string) {
+  t.ImportDeclaration.assert(path.node);
+
+  // Bail if no filename was provided for the current source file.
+  // Also never traverse into react itself.
+  const source = path.node.source.value;
+  const options = getOptions(path);
+  if (!options || !options.filename || source === 'react') {
+    return null;
+  }
+
+  // Resolve the imported module using the Node resolver
+  const basedir = dirname(options.filename);
+  let resolvedSource;
+
+  try {
+    resolvedSource = resolve.sync(source, {
+      basedir,
+      extensions: ['.js', '.jsx', '.ts', '.tsx'],
+    });
+  } catch (err) {
+    return null;
+  }
+
+  // Read and parse the code
+  // TODO: cache and reuse
+  const code = fs.readFileSync(resolvedSource, 'utf8');
+  const parseOptions: Options = {
+    ...options,
+    parserOptions: {},
+    filename: resolvedSource,
+  };
+
+  const parser = buildParser(parseOptions);
+  const ast = parser.parse(code);
+  return findExportedValue(ast.program, name);
+}
+
+// Find the root Program node, which we attached our options too in babelParser.js
+function getOptions(path: NodePath): Options {
+  while (!t.Program.check(path.node)) {
+    path = path.parentPath;
+  }
+
+  return path.node.options || {};
+}
+
+// Traverses the program looking for an export that matches the requested name
+function findExportedValue(ast, name) {
+  let resultPath: ?NodePath = null;
+
+  traverseShallow(ast, {
+    visitExportNamedDeclaration(path: NodePath) {
+      const { declaration, specifiers } = path.node;
+      if (declaration && declaration.id && declaration.id.name === name) {
+        resultPath = path.get('declaration');
+      } else if (declaration && declaration.declarations) {
+        path.get('declaration', 'declarations').each((declPath: NodePath) => {
+          const decl = declPath.node;
+          // TODO: ArrayPattern and ObjectPattern
+          if (
+            t.Identifier.check(decl.id) &&
+            decl.id.name === name &&
+            decl.init
+          ) {
+            resultPath = declPath.get('init');
+          }
+        });
+      } else if (specifiers) {
+        path.get('specifiers').each((specifierPath: NodePath) => {
+          if (specifierPath.node.exported.name === name) {
+            resultPath = specifierPath.get('local');
+          }
+        });
+      }
+
+      return false;
+    },
+    visitExportDefaultDeclaration(path: NodePath) {
+      if (name === 'default') {
+        resultPath = path.get('declaration');
+      }
+
+      return false;
+    },
+    // TODO: visitExportAllDeclaration
+  });
+
+  return resultPath;
+}

--- a/src/utils/resolveImportedValue.js
+++ b/src/utils/resolveImportedValue.js
@@ -74,7 +74,7 @@ function findExportedValue(ast, name, seen) {
 
   traverseShallow(ast, {
     visitExportNamedDeclaration(path: NodePath) {
-      const { declaration, specifiers } = path.node;
+      const { declaration, specifiers, source } = path.node;
       if (declaration && declaration.id && declaration.id.name === name) {
         resultPath = path.get('declaration');
       } else if (declaration && declaration.declarations) {
@@ -92,7 +92,12 @@ function findExportedValue(ast, name, seen) {
       } else if (specifiers) {
         path.get('specifiers').each((specifierPath: NodePath) => {
           if (specifierPath.node.exported.name === name) {
-            resultPath = specifierPath.get('local');
+            if (source) {
+              const local = specifierPath.node.local.name;
+              resultPath = resolveImportedValue(path, local, seen);
+            } else {
+              resultPath = specifierPath.get('local');
+            }
           }
         });
       }

--- a/src/utils/resolveImportedValue.js
+++ b/src/utils/resolveImportedValue.js
@@ -36,7 +36,7 @@ export default function resolveImportedValue(
   try {
     resolvedSource = resolve.sync(source, {
       basedir,
-      extensions: ['.js', '.jsx', '.ts', '.tsx'],
+      extensions: ['.js', '.jsx', '.mjs', '.ts', '.tsx'],
     });
   } catch (err) {
     return null;

--- a/src/utils/resolveToModule.js
+++ b/src/utils/resolveToModule.js
@@ -33,7 +33,7 @@ export default function resolveToModule(path: NodePath): ?string {
       return resolveToModule(path.get('callee'));
     case t.Identifier.name:
     case t.JSXIdentifier.name: {
-      const valuePath = resolveToValue(path);
+      const valuePath = resolveToValue(path, false);
       if (valuePath !== path) {
         return resolveToModule(valuePath);
       }

--- a/src/utils/resolveToValue.js
+++ b/src/utils/resolveToValue.js
@@ -167,7 +167,9 @@ export default function resolveToValue(
       return propertyPath;
     } else if (isSupportedDefinitionType(resolved)) {
       const memberPath = getMemberValuePath(resolved, path.node.property.name);
-      return memberPath || path;
+      if (memberPath) {
+        return resolveToValue(memberPath, resolveImports);
+      }
     } else if (t.ImportDeclaration.check(resolved.node)) {
       // Handle references to namespace imports, e.g. import * as foo from 'bar'.
       // Try to find a specifier that matches the root of the member expression, and

--- a/src/utils/resolveToValue.js
+++ b/src/utils/resolveToValue.js
@@ -149,10 +149,7 @@ export default function resolveToValue(
     }
   } else if (t.MemberExpression.check(node)) {
     const root = getMemberExpressionRoot(path);
-    let resolved = resolveToValue(
-      root,
-      resolveImports,
-    );
+    const resolved = resolveToValue(root, resolveImports);
     if (t.ObjectExpression.check(resolved.node)) {
       let propertyPath = resolved;
       for (const propertyName of toArray(path).slice(1)) {
@@ -174,9 +171,15 @@ export default function resolveToValue(
       // Handle references to namespace imports, e.g. import * as foo from 'bar'.
       // Try to find a specifier that matches the root of the member expression, and
       // find the export that matches the property name.
-      for (let specifier of resolved.node.specifiers) {
-        if (t.ImportNamespaceSpecifier.check(specifier) && specifier.local.name === root.node.name) {
-          const resolvedPath = resolveImportedValue(resolved, root.parentPath.node.property.name);
+      for (const specifier of resolved.node.specifiers) {
+        if (
+          t.ImportNamespaceSpecifier.check(specifier) &&
+          specifier.local.name === root.node.name
+        ) {
+          const resolvedPath = resolveImportedValue(
+            resolved,
+            root.parentPath.node.property.name,
+          );
           if (resolvedPath) {
             return resolveToValue(resolvedPath, resolveImports);
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4041,6 +4041,13 @@ resolve@^1.10.0, resolve@^1.3.2, resolve@^1.8.1:
   dependencies:
     path-parse "^1.0.6"
 
+resolve@^1.10.1:
+  version "1.10.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.10.1.tgz#664842ac960795bbe758221cdccda61fb64b5f18"
+  integrity sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==
+  dependencies:
+    path-parse "^1.0.6"
+
 restore-cursor@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"


### PR DESCRIPTION
Closes #33.

This adds support for importing propTypes, flow, and typescript from other modules. Various people have tried to do this through external handlers in the past, but this has been more challenging because they have needed to reimplement or copy many of the builtin helper functions available in react-docgen. This PR adds builtin support for importing, and should be much simpler than external solutions.

Current limitations:

* ES6 imports only. Could add CommonJS support, but it's a bit more complicated and I'm not sure it's worth it when most apps should be using ES6 now anyway.
* Resolving from `node_modules` is supported, but flow libdefs (`flow-typed` folder, `.js.flow` files, and `.d.ts` files) are unsupported. Would need to reimplement a custom resolver for those.

Some of these could be resolved, but we could also decide to leave some for future enhancements in order to start somewhere.

- [ ] Allow different resolvers
- [ ] Allow to disable resolving imports