### PR TITLE
Fix false-positive react component classes

### DIFF
--- a/src/__tests__/fixtures/component_15.js
+++ b/src/__tests__/fixtures/component_15.js
@@ -1,4 +1,5 @@
 import type {Props as BarProps} from 'Bar.react';
+import React from 'react';
 
 const Bar = require('Bar.react');
 

--- a/src/__tests__/fixtures/component_9.js
+++ b/src/__tests__/fixtures/component_9.js
@@ -2,6 +2,8 @@
  * Testing render method as public class field.
  */
 import view from "./view.jsx";
+import {Component as SomeOtherComponent} from 'react';
+
 /**
  * Should be recognized as component.
  */

--- a/src/handlers/__tests__/componentMethodsHandler-test.js
+++ b/src/handlers/__tests__/componentMethodsHandler-test.js
@@ -94,7 +94,8 @@ describe('componentMethodsHandler', () => {
 
   it('extracts the documentation for a ClassDeclaration', () => {
     const src = `
-      class Test {
+      import React from 'react';
+      class Test extends React.Component {
         /**
          * The foo method
          */
@@ -124,12 +125,13 @@ describe('componentMethodsHandler', () => {
       }
     `;
 
-    test(parse(src).get('body', 0));
+    test(parse(src).get('body', 1));
   });
 
   it('should handle and ignore computed methods', () => {
     const src = `
-      class Test {
+      import React from 'react';
+      class Test extends React.Component {
         /**
          * The foo method
          */
@@ -152,7 +154,7 @@ describe('componentMethodsHandler', () => {
       }
     `;
 
-    componentMethodsHandler(documentation, parse(src).get('body', 0));
+    componentMethodsHandler(documentation, parse(src).get('body', 1));
     expect(documentation.methods).toMatchSnapshot();
   });
 

--- a/src/resolver/__tests__/findAllComponentDefinitions-test.js
+++ b/src/resolver/__tests__/findAllComponentDefinitions-test.js
@@ -107,7 +107,7 @@ describe('findAllComponentDefinitions', () => {
 
       const result = parse(source);
       expect(Array.isArray(result)).toBe(true);
-      expect(result.length).toBe(4);
+      expect(result.length).toBe(2);
     });
 
     it('finds React.createClass, independent of the var name', () => {

--- a/src/utils/__tests__/isReactComponentClass-test.js
+++ b/src/utils/__tests__/isReactComponentClass-test.js
@@ -6,40 +6,10 @@
  *
  */
 
-import { expression, statement, parse } from '../../../tests/utils';
+import { parse } from '../../../tests/utils';
 import isReactComponentClass from '../isReactComponentClass';
 
 describe('isReactComponentClass', () => {
-  describe('render method', () => {
-    it('accepts class declarations with a render method', () => {
-      const def = statement('class Foo { render() {}}');
-      expect(isReactComponentClass(def)).toBe(true);
-    });
-
-    it('accepts class expression with a render method', () => {
-      const def = expression('class { render() {}}');
-      expect(isReactComponentClass(def)).toBe(true);
-    });
-
-    it('ignores static render methods', () => {
-      const def = statement('class Foo { static render() {}}');
-      expect(isReactComponentClass(def)).toBe(false);
-    });
-
-    it('ignores dynamic render methods', () => {
-      const def = statement('class Foo { static [render]() {}}');
-      expect(isReactComponentClass(def)).toBe(false);
-    });
-
-    it('ignores getter or setter render methods', () => {
-      let def = statement('class Foo { get render() {}}');
-      expect(isReactComponentClass(def)).toBe(false);
-
-      def = statement('class Foo { set render(value) {}}');
-      expect(isReactComponentClass(def)).toBe(false);
-    });
-  });
-
   describe('JSDoc @extends React.Component', () => {
     it('accepts class declarations declaring `@extends React.Component` in JSDoc', () => {
       const def = parse(`
@@ -91,15 +61,6 @@ describe('isReactComponentClass', () => {
       `).get('body', 1);
 
       expect(isReactComponentClass(def)).toBe(false);
-    });
-
-    it('does not consider super class if render method is present', () => {
-      const def = parse(`
-        var {Component} = require('FakeReact');
-        class Foo extends Component { render() {} }
-      `).get('body', 1);
-
-      expect(isReactComponentClass(def)).toBe(true);
     });
   });
 });

--- a/src/utils/isReactComponentClass.js
+++ b/src/utils/isReactComponentClass.js
@@ -9,38 +9,19 @@
 
 import types from 'ast-types';
 import isReactModuleName from './isReactModuleName';
-import match from './match';
 import resolveToModule from './resolveToModule';
 import resolveToValue from './resolveToValue';
 
 const { namedTypes: t } = types;
 
-function isRenderMethod(node) {
-  const isProperty = node.type === 'ClassProperty';
-  return (
-    (t.MethodDefinition.check(node) || isProperty) &&
-    !node.computed &&
-    !node.static &&
-    (node.kind === '' || node.kind === 'method' || isProperty) &&
-    node.key.name === 'render'
-  );
-}
-
 /**
- * Returns `true` of the path represents a class definition which either extends
- * `React.Component` or implements a `render()` method.
+ * Returns `true` of the path represents a class definition which extends `React.Component`
  */
 export default function isReactComponentClass(path: NodePath): boolean {
   const node = path.node;
   if (!t.ClassDeclaration.check(node) && !t.ClassExpression.check(node)) {
     return false;
   }
-
-  // render method
-  if (node.body.body.some(isRenderMethod)) {
-    return true;
-  }
-
   // check for @extends React.Component in docblock
   if (path.parentPath && path.parentPath.value) {
     const classDeclaration = Array.isArray(path.parentPath.value)
@@ -65,9 +46,6 @@ export default function isReactComponentClass(path: NodePath): boolean {
     return false;
   }
   const superClass = resolveToValue(path.get('superClass'));
-  if (!match(superClass.node, { property: { name: 'Component' } })) {
-    return false;
-  }
   const module = resolveToModule(superClass);
   return !!module && isReactModuleName(module);
 }


### PR DESCRIPTION
Currently, any class with a `render` method is considered to be a React component. This causes issues with code-bases where not everything is React, and there are other classes besides components with render methods. These should not be documented as components by react-docgen.

This PR removes the detection of React components by `render` method, and requires those classes to extend from `React.Component` or other classes in the `react` module. This is obviously a breaking change, but I believe it is more correct since React component classes must extend from `React.Component` to be considered valid by React as well. If there are use cases that cannot be handled by this, we should accommodate them in other ways.