### PR TITLE
fix: Hocs resolving intermediate values

### DIFF
--- a/src/utils/__tests__/resolveHOC-test.js
+++ b/src/utils/__tests__/resolveHOC-test.js
@@ -47,4 +47,11 @@ describe('resolveHOC', () => {
     );
     expect(resolveHOC(path)).toEqualASTNode(builders.literal(42));
   });
+
+  it('resolves intermediate hocs', () => {
+    const path = parse(
+      ['const Component = React.memo(42);', 'hoc()(Component);'].join('\n'),
+    );
+    expect(resolveHOC(path)).toEqualASTNode(builders.literal(42));
+  });
 });

--- a/src/utils/resolveHOC.js
+++ b/src/utils/resolveHOC.js
@@ -10,6 +10,7 @@
 import types from 'ast-types';
 import isReactCreateClassCall from './isReactCreateClassCall';
 import isReactForwardRefCall from './isReactForwardRefCall';
+import resolveToValue from './resolveToValue';
 
 const { namedTypes: t } = types;
 
@@ -27,7 +28,9 @@ export default function resolveHOC(path: NodePath): NodePath {
     !isReactForwardRefCall(path)
   ) {
     if (node.arguments.length) {
-      return resolveHOC(path.get('arguments', node.arguments.length - 1));
+      return resolveHOC(
+        resolveToValue(path.get('arguments', node.arguments.length - 1)),
+      );
     }
   }
 


### PR DESCRIPTION
Used when static properties need to be defined on intermediate values.