### PR TITLE
Support ts(x) file parsing using CLI

### DIFF
--- a/bin/react-docgen.js
+++ b/bin/react-docgen.js
@@ -207,7 +207,7 @@ if (errorMessage) {
           }
         } else {
           try {
-            result[filePath] = parse(fs.readFileSync(filePath));
+            result[filePath] = parse(fs.readFileSync(filePath), filePath);
           } catch (parseError) {
             writeError(parseError, filePath);
           } finally {


### PR DESCRIPTION
## Why
The current implementation of `react-docgen` CLI doesn't support passing a single `*.ts(x)` file for parsing. As you can see from the source code, internal function `parse` is called with only one parameter (content of the required file), however, in order to specify that the file should be parsed according to the TypeScript spec, we need pass `options` to the `babelParser` that should contain a filename with `ts(x)` extension. If we don't pass `filePath` (see my patch), `options` object will become empty and `flow` parser will be used instead (which is incompatible with some TypeScript features).

## Scope of the bug
This bug only affects react-codegen CLI tool

## Solution
Pass `filePath` along with the file content