### PR TITLE
Be more strict about detecting react class components

### DIFF
--- a/src/handlers/__tests__/componentMethodsHandler-test.js
+++ b/src/handlers/__tests__/componentMethodsHandler-test.js
@@ -94,7 +94,7 @@ describe('componentMethodsHandler', () => {
 
   it('extracts the documentation for a ClassDeclaration', () => {
     const src = `
-      class Test {
+      class Test extends React.Component {
         /**
          * The foo method
          */
@@ -129,7 +129,7 @@ describe('componentMethodsHandler', () => {
 
   it('should handle and ignore computed methods', () => {
     const src = `
-      class Test {
+      class Test extends React.Component {
         /**
          * The foo method
          */

--- a/src/resolver/__tests__/findAllComponentDefinitions-test.js
+++ b/src/resolver/__tests__/findAllComponentDefinitions-test.js
@@ -99,9 +99,9 @@ describe('findAllComponentDefinitions', () => {
       const source = `
         import React from 'React';
         class ComponentA extends React.Component {}
-        class ComponentB { render() {} }
-        var ComponentC = class extends React.Component {}
-        var ComponentD = class { render() {} }
+        class ComponentB extends Foo { render() {} }
+        var ComponentC = class extends React.PureComponent {}
+        var ComponentD = class extends Bar { render() {} }
         class NotAComponent {}
       `;
 

--- a/src/utils/isReactComponentClass.js
+++ b/src/utils/isReactComponentClass.js
@@ -28,12 +28,29 @@ function isRenderMethod(node) {
 
 /**
  * Returns `true` of the path represents a class definition which either extends
- * `React.Component` or implements a `render()` method.
+ * `React.Component` or has a superclass and implements a `render()` method.
  */
 export default function isReactComponentClass(path: NodePath): boolean {
   const node = path.node;
   if (!t.ClassDeclaration.check(node) && !t.ClassExpression.check(node)) {
     return false;
+  }
+
+  // extends something
+  if (!node.superClass) {
+    return false;
+  }
+
+  // React.Component or React.PureComponent
+  const superClass = resolveToValue(path.get('superClass'));
+  if (
+    match(superClass.node, { property: { name: 'Component' } }) ||
+    match(superClass.node, { property: { name: 'PureComponent' } })
+  ) {
+    const module = resolveToModule(superClass);
+    if (module && isReactModuleName(module)) {
+      return true;
+    }
   }
 
   // render method
@@ -60,14 +77,5 @@ export default function isReactComponentClass(path: NodePath): boolean {
     }
   }
 
-  // extends ReactComponent?
-  if (!node.superClass) {
-    return false;
-  }
-  const superClass = resolveToValue(path.get('superClass'));
-  if (!match(superClass.node, { property: { name: 'Component' } })) {
-    return false;
-  }
-  const module = resolveToModule(superClass);
-  return !!module && isReactModuleName(module);
+  return false;
 }


### PR DESCRIPTION
Previously a class just needed to have a `render` method.
Now it in addition requires to have a superclass as well.

Also adds support for `React.PureComponent` in `isReactComponentClass.js`

Subset of #354 