### PR TITLE
fix: bail when function returns are recursive instead of stack overflowing

### DIFF
--- a/src/utils/__tests__/isStatelessComponent-test.js
+++ b/src/utils/__tests__/isStatelessComponent-test.js
@@ -6,7 +6,7 @@
  *
  */
 
-import { statement, parse } from '../../../tests/utils';
+import { parse, statement } from '../../../tests/utils';
 import isStatelessComponent from '../isStatelessComponent';
 
 describe('isStatelessComponent', () => {
@@ -231,6 +231,16 @@ describe('isStatelessComponent', () => {
       `);
 
       expect(isStatelessComponent(def)).toBe(true);
+    });
+
+    it('handles recursive function calls', () => {
+      const def = statement(`
+        function Foo (props) {
+          return props && Foo(props);
+        }
+      `);
+
+      expect(isStatelessComponent(def)).toBe(false);
     });
 
     test(


### PR DESCRIPTION
exported functions that are recursive will loop unless we check the resolution logic at some point