### PR TITLE
feat(typescript): add private modifier for private methods

### DIFF
--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -1398,7 +1398,47 @@ Object {
       "description": "This is a method",
       "docblock": "This is a method",
       "modifiers": Array [],
-      "name": "method",
+      "name": "foo",
+      "params": Array [
+        Object {
+          "name": "a",
+          "type": Object {
+            "name": "string",
+          },
+        },
+      ],
+      "returns": Object {
+        "type": Object {
+          "name": "string",
+        },
+      },
+    },
+    Object {
+      "description": "This is a public method",
+      "docblock": "This is a public method",
+      "modifiers": Array [],
+      "name": "bar",
+      "params": Array [
+        Object {
+          "name": "a",
+          "type": Object {
+            "name": "string",
+          },
+        },
+      ],
+      "returns": Object {
+        "type": Object {
+          "name": "string",
+        },
+      },
+    },
+    Object {
+      "description": "This is a private method",
+      "docblock": "This is a private method",
+      "modifiers": Array [
+        "private",
+      ],
+      "name": "baz",
       "params": Array [
         Object {
           "name": "a",

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -1432,27 +1432,6 @@ Object {
         },
       },
     },
-    Object {
-      "description": "This is a private method",
-      "docblock": "This is a private method",
-      "modifiers": Array [
-        "private",
-      ],
-      "name": "baz",
-      "params": Array [
-        Object {
-          "name": "a",
-          "type": Object {
-            "name": "string",
-          },
-        },
-      ],
-      "returns": Object {
-        "type": Object {
-          "name": "string",
-        },
-      },
-    },
   ],
   "props": Object {
     "foo": Object {

--- a/src/__tests__/fixtures/component_27.tsx
+++ b/src/__tests__/fixtures/component_27.tsx
@@ -23,7 +23,21 @@ export default class TSComponent extends Component<Props> {
   /**
    * This is a method
    */
-  method(a: string): string {
+  foo(a: string): string {
+    return a;
+  }
+
+  /**
+   * This is a public method
+   */
+  public bar(a: string): string {
+    return a;
+  }
+
+  /**
+   * This is a private method
+   */
+  private baz(a: string): string {
     return a;
   }
 }

--- a/src/utils/__tests__/__snapshots__/getMethodDocumentation-test.js.snap
+++ b/src/utils/__tests__/__snapshots__/getMethodDocumentation-test.js.snap
@@ -11,3 +11,5 @@ Object {
 `;
 
 exports[`getMethodDocumentation name ignores complex computed method name 1`] = `null`;
+
+exports[`getMethodDocumentation parameters private ignores private typescript methods 1`] = `null`;

--- a/src/utils/__tests__/getMethodDocumentation-test.js
+++ b/src/utils/__tests__/getMethodDocumentation-test.js
@@ -202,5 +202,33 @@ describe('getMethodDocumentation', () => {
         );
       });
     });
+
+    describe('private', () => {
+      it('ignores private typescript methods', () => {
+        const def = statement(
+          `
+          class Foo {
+            private foo() {}
+          }
+        `,
+          { parserOptions: { plugins: ['typescript'] } },
+        );
+        const method = def.get('body', 'body', 0);
+        expect(getMethodDocumentation(method)).toMatchSnapshot();
+      });
+
+      it.skip('ignores private methods', () => {
+        const def = statement(
+          `
+          class Foo {
+            #foo() {}
+          }
+        `,
+          { parserOptions: { plugins: ['classPrivateMethods'] } },
+        );
+        const method = def.get('body', 'body', 0);
+        expect(getMethodDocumentation(method)).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/src/utils/getMethodDocumentation.js
+++ b/src/utils/getMethodDocumentation.js
@@ -93,6 +93,10 @@ function getMethodModifiers(methodPath) {
     modifiers.push(methodPath.node.kind);
   }
 
+  if (methodPath.node.accessibility === 'private') {
+    modifiers.push(methodPath.node.accessibility);
+  }
+
   const functionExpression = methodPath.get('value').node;
   if (functionExpression.generator) {
     modifiers.push('generator');

--- a/src/utils/getMethodDocumentation.js
+++ b/src/utils/getMethodDocumentation.js
@@ -93,10 +93,6 @@ function getMethodModifiers(methodPath) {
     modifiers.push(methodPath.node.kind);
   }
 
-  if (methodPath.node.accessibility === 'private') {
-    modifiers.push(methodPath.node.accessibility);
-  }
-
   const functionExpression = methodPath.get('value').node;
   if (functionExpression.generator) {
     modifiers.push('generator');
@@ -111,6 +107,10 @@ function getMethodModifiers(methodPath) {
 export default function getMethodDocumentation(
   methodPath: NodePath,
 ): ?MethodDocumentation {
+  if (methodPath.node.accessibility === 'private') {
+    return null;
+  }
+
   const name = getPropertyName(methodPath);
   if (!name) return null;
 


### PR DESCRIPTION
When generating documentation for methods in class components using TypeScript, I have some methods marked as `private` because they are internal and don't want to show them in the docs. But I don't have any information regarding whether a method is public or private in the currently extracted metadata. In this PR, I'm adding a modifier for private methods so I can know which methods to exclude.