### PR TITLE
Do not forward typeParameters when using resolved Path

### DIFF
--- a/src/utils/__tests__/getTSType-test.js
+++ b/src/utils/__tests__/getTSType-test.js
@@ -636,6 +636,22 @@ describe('getTSType', () => {
     });
   });
 
+  it('handles generics of the same Name', () => {
+    const typePath = statement(`
+      interface Props {
+        baz: Foo<T>
+      }
+
+      type Foo<T> = Bar<T>
+
+    `)
+      .get('body')
+      .get('body', 0)
+      .get('typeAnnotation');
+
+    getTSType(typePath);
+  });
+
   it('handles self-referencing type cycles', () => {
     const typePath = statement(`
       let action: Action;

--- a/src/utils/getTSType.js
+++ b/src/utils/getTSType.js
@@ -100,7 +100,7 @@ function handleTSTypeReference(
   }
 
   if (typeParams && typeParams[type.name]) {
-    type = getTSTypeWithResolvedTypes(resolvedPath, typeParams);
+    type = getTSTypeWithResolvedTypes(resolvedPath);
   }
 
   if (resolvedPath && resolvedPath.node.typeAnnotation) {


### PR DESCRIPTION
fixes #410 

We were incorrectly forwarding the typeparams while resolving a new type (the resolved one) which might have new or different type params. 