### PR TITLE
Fix to Flow Maximum Callstack exceeded error on recursive generic structs

### DIFF
--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -1516,3 +1516,64 @@ Object {
   },
 }
 `;
+
+exports[`main fixtures processes component "component_32.js" without errors 1`] = `
+Object {
+  "description": "",
+  "displayName": "Segments",
+  "methods": Array [
+    Object {
+      "docblock": null,
+      "modifiers": Array [],
+      "name": "foo",
+      "params": Array [
+        Object {
+          "name": "props",
+          "optional": undefined,
+          "type": Object {
+            "alias": "Props",
+            "name": "signature",
+            "raw": "{
+  segments: Array<T>,
+}",
+            "signature": Object {
+              "properties": Array [
+                Object {
+                  "key": "segments",
+                  "value": Object {
+                    "elements": Array [
+                      Object {
+                        "name": "T",
+                      },
+                    ],
+                    "name": "Array",
+                    "raw": "Array<T>",
+                    "required": true,
+                  },
+                },
+              ],
+            },
+            "type": "object",
+          },
+        },
+      ],
+      "returns": null,
+    },
+  ],
+  "props": Object {
+    "segments": Object {
+      "description": "",
+      "flowType": Object {
+        "elements": Array [
+          Object {
+            "name": "T",
+          },
+        ],
+        "name": "Array",
+        "raw": "Array<T>",
+      },
+      "required": true,
+    },
+  },
+}
+`;

--- a/src/__tests__/__snapshots__/main-test.js.snap
+++ b/src/__tests__/__snapshots__/main-test.js.snap
@@ -1465,3 +1465,54 @@ Object {
   },
 }
 `;
+
+exports[`main fixtures processes component "component_29.js" without errors 1`] = `
+Object {
+  "description": "",
+  "displayName": "MyComponent",
+  "methods": Array [],
+  "props": Object {
+    "prop": Object {
+      "description": "",
+      "flowType": Object {
+        "name": "T",
+      },
+      "required": true,
+    },
+  },
+}
+`;
+
+exports[`main fixtures processes component "component_30.js" without errors 1`] = `
+Object {
+  "description": "",
+  "displayName": "MyComponent",
+  "methods": Array [],
+  "props": Object {
+    "prop": Object {
+      "description": "",
+      "flowType": Object {
+        "name": "string",
+      },
+      "required": true,
+    },
+  },
+}
+`;
+
+exports[`main fixtures processes component "component_31.js" without errors 1`] = `
+Object {
+  "description": "",
+  "displayName": "MyComponent",
+  "methods": Array [],
+  "props": Object {
+    "prop": Object {
+      "description": "",
+      "flowType": Object {
+        "name": "T",
+      },
+      "required": true,
+    },
+  },
+}
+`;

--- a/src/__tests__/fixtures/component_29.js
+++ b/src/__tests__/fixtures/component_29.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+type Identity<T> = T;
+
+type Props<T> = {
+  prop: Identity<T>,
+}
+
+export default function MyComponent<T>(props: Props<T>) {
+  return <div>Hello World</div>
+}

--- a/src/__tests__/fixtures/component_30.js
+++ b/src/__tests__/fixtures/component_30.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+type Identity<T> = T;
+
+type Props = {
+  prop: Identity<string>,
+}
+
+export default function MyComponent(props: Props) {
+  return <div>Hello World</div>
+}

--- a/src/__tests__/fixtures/component_31.js
+++ b/src/__tests__/fixtures/component_31.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+type Identity<T> = T;
+
+type Props<T> = {
+  prop: Identity<Identity<T>>,
+}
+
+export default function MyComponent<T>(props: Props<T>) {
+  return <div>Hello World</div>
+}

--- a/src/__tests__/fixtures/component_32.js
+++ b/src/__tests__/fixtures/component_32.js
@@ -1,0 +1,13 @@
+import * as React from "react";
+
+type Props<T> = {
+  segments: Array<T>,
+};
+
+export default class Segments<T> extends React.Component<Props<T>> {
+  render(): React.Node {
+    return null;
+  }
+
+  foo(props: Props<T>) {}
+}

--- a/src/utils/getFlowType.js
+++ b/src/utils/getFlowType.js
@@ -139,6 +139,14 @@ function handleGenericTypeAnnotation(
     );
   }
 
+  if (
+    typeParams &&
+    typeParams[type.name] &&
+    typeParams[type.name].value.type === t.GenericTypeAnnotation.name
+  ) {
+    return type;
+  }
+
   if (typeParams && typeParams[type.name]) {
     type = getFlowTypeWithResolvedTypes(resolvedPath, typeParams);
   }


### PR DESCRIPTION
Resolves https://github.com/reactjs/react-docgen/issues/427

Nested structs using generics currently cause a `maximum callstack exceeded` error. This PR resolves the issue by short-circuiting the recursion when the type resolves to a generic.

This approach has a shortcoming where the below example will resolve the prop `prop` as `T` instead of as `string`. But this is currently the same behavior seen when switching to typescript and should be fine since it's an an overall improvement to docgen erroring.

```jsx
import * as React from "react";

type Identity<T> = T;

type Props<T> = {
  prop: Identity<T>;
}

export default function Test(props: Props<string>) {
  return <div />;
}
```

I'm happy to iterate on this PR, let me know if you need me to change anything.
