### PR TITLE
fix: support forwardRef with out of line argument

### DIFF
--- a/src/handlers/__tests__/__snapshots__/defaultPropsHandler-test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/defaultPropsHandler-test.js.snap
@@ -299,6 +299,17 @@ Object {
 }
 `;
 
+exports[`defaultPropsHandler forwardRef resolves when the function is not inline 1`] = `
+Object {
+  "foo": Object {
+    "defaultValue": Object {
+      "computed": false,
+      "value": "'bar'",
+    },
+  },
+}
+`;
+
 exports[`defaultPropsHandler should only consider Property nodes, not e.g. spread properties 1`] = `
 Object {
   "bar": Object {

--- a/src/handlers/__tests__/defaultPropsHandler-test.js
+++ b/src/handlers/__tests__/defaultPropsHandler-test.js
@@ -290,5 +290,18 @@ describe('defaultPropsHandler', () => {
       defaultPropsHandler(documentation, parse(src).get('body', 1));
       expect(documentation.descriptors).toMatchSnapshot();
     });
+
+    it('resolves when the function is not inline', () => {
+      const src = `
+        import React from 'react';
+        const ComponentImpl = ({ foo = 'bar' }, ref) => <div ref={ref}>{foo}</div>;
+        React.forwardRef(ComponentImpl);
+      `;
+      defaultPropsHandler(
+        documentation,
+        parse(src).get('body', 2, 'expression'),
+      );
+      expect(documentation.descriptors).toMatchSnapshot();
+    });
   });
 });

--- a/src/handlers/__tests__/flowTypeHandler-test.js
+++ b/src/handlers/__tests__/flowTypeHandler-test.js
@@ -8,7 +8,7 @@
 
 jest.mock('../../Documentation');
 
-import { expression, statement } from '../../../tests/utils';
+import { expression, statement, parse } from '../../../tests/utils';
 
 describe('flowTypeHandler', () => {
   let getFlowTypeMock;
@@ -332,6 +332,41 @@ describe('flowTypeHandler', () => {
         var React = require('React');
         var Component = React.Component;
       `);
+    });
+  });
+
+  describe('forwardRef', () => {
+    it('resolves prop type from function expression', () => {
+      const src = `
+        import React from 'react';
+        type Props = { foo: string };
+        React.forwardRef((props: Props, ref) => <div ref={ref}>{props.foo}</div>);
+      `;
+      flowTypeHandler(documentation, parse(src).get('body', 2, 'expression'));
+      expect(documentation.descriptors).toEqual({
+        foo: {
+          flowType: {},
+          required: true,
+          description: '',
+        },
+      });
+    });
+
+    it('resolves when the function is not inline', () => {
+      const src = `
+        import React from 'react';
+        type Props = { foo: string };
+        const ComponentImpl = (props: Props, ref) => <div ref={ref}>{props.foo}</div>;
+        React.forwardRef(ComponentImpl);
+      `;
+      flowTypeHandler(documentation, parse(src).get('body', 3, 'expression'));
+      expect(documentation.descriptors).toEqual({
+        foo: {
+          flowType: {},
+          required: true,
+          description: '',
+        },
+      });
     });
   });
 });

--- a/src/handlers/defaultPropsHandler.js
+++ b/src/handlers/defaultPropsHandler.js
@@ -51,7 +51,7 @@ function getDefaultValue(path: NodePath) {
 function getStatelessPropsPath(componentDefinition): NodePath {
   const value = resolveToValue(componentDefinition);
   if (isReactForwardRefCall(value)) {
-    const inner = value.get('arguments', 0);
+    const inner = resolveToValue(value.get('arguments', 0));
     return inner.get('params', 0);
   }
   return value.get('params', 0);

--- a/src/utils/getFlowTypeFromReactComponent.js
+++ b/src/utils/getFlowTypeFromReactComponent.js
@@ -19,7 +19,7 @@ import resolveToValue from './resolveToValue';
 function getStatelessPropsPath(componentDefinition): NodePath {
   const value = resolveToValue(componentDefinition);
   if (isReactForwardRefCall(value)) {
-    const inner = value.get('arguments', 0);
+    const inner = resolveToValue(value.get('arguments', 0));
     return inner.get('params', 0);
   }
   return value.get('params', 0);


### PR DESCRIPTION
Enables handlers that support `forwardRef` (`defaultProps` and Flow type handling) to work when the argument to `forwardRef` is a reference to a function defined outside of the `forwardRef` call:

```jsx
import React from 'react';
const ComponentImpl = ({ foo = 'bar' }, ref) => <div ref={ref}>{foo}</div>;
React.forwardRef(ComponentImpl);
```

This is achieved by reusing `resolveToValue`.

Note that this does **not** fix the rebinding case, which I intend to tackle separately:

```jsx
import React from 'react';
let ComponentImpl = ({ foo = 'bar' }, ref) => <div ref={ref}>{foo}</div>;
ComponentImpl = React.forwardRef(ComponentImpl); // resolveToValue resolves here :/
```