### PR TITLE
fix(flow): support empty type

### DIFF
--- a/src/utils/__tests__/getFlowType-test.js
+++ b/src/utils/__tests__/getFlowType-test.js
@@ -19,6 +19,7 @@ describe('getFlowType', () => {
       'mixed',
       'null',
       'void',
+      'empty',
       'Object',
       'Function',
       'Boolean',

--- a/src/utils/getFlowType.js
+++ b/src/utils/getFlowType.js
@@ -32,6 +32,7 @@ const flowTypes = {
   NumberTypeAnnotation: 'number',
   StringTypeAnnotation: 'string',
   VoidTypeAnnotation: 'void',
+  EmptyTypeAnnotation: 'empty',
 };
 
 const flowLiteralTypes = {


### PR DESCRIPTION
The Flow `empty` type (`EmptyTypeAnnotation`) is currently represented by the catch-all string `"unknown"`. With this change it will be represented by `"empty"`.