### PR TITLE
fix(traverse): only visit paths, not nodes

### DIFF
--- a/src/utils/resolveToValue.js
+++ b/src/utils/resolveToValue.js
@@ -75,7 +75,7 @@ function findScopePath(paths: Array<NodePath>, path: NodePath): ?NodePath {
 function findLastAssignedValue(scope, name) {
   const results = [];
 
-  traverseShallow(scope.path.node, {
+  traverseShallow(scope.path, {
     visitAssignmentExpression: function(path) {
       const node = path.node;
       // Skip anything that is not an assignment to a variable with the

--- a/src/utils/traverse.js
+++ b/src/utils/traverse.js
@@ -16,10 +16,10 @@ type Visitor = (path: NodePath) => any;
  * default.
  */
 export function traverseShallow(
-  ast: ASTNode,
+  path: NodePath,
   visitors: { [key: string]: Visitor },
 ): void {
-  visit(ast, { ...defaultVisitors, ...visitors });
+  visit(path, { ...defaultVisitors, ...visitors });
 }
 
 const ignore = () => false;


### PR DESCRIPTION
Traversing with `visit` using a node as the root creates a new `NodePath`, which detaches the resulting paths from the root `File` node. I've seen this lead to `getFlowType` crashing later when it tries to grab the source code from the no-longer-reachable `File` node[1]. Traversing from a `NodePath` keeps everything correctly linked and has no downsides AFAICT, so here I changed `traverseShallow` (which wraps `visit`) to only accept paths.

[1] I don't have the exact repro case to hand, unfortunately, but this was in the course of working on https://github.com/facebook/react-native-website/pull/1628.