### PR TITLE
feat(methods): support static methods on function components

### DIFF
--- a/src/handlers/__tests__/__snapshots__/componentMethodsHandler-test.js.snap
+++ b/src/handlers/__tests__/__snapshots__/componentMethodsHandler-test.js.snap
@@ -1,5 +1,74 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`componentMethodsHandler function components finds static methods on a component in a variable declaration 1`] = `
+Array [
+  Object {
+    "docblock": null,
+    "modifiers": Array [
+      "static",
+    ],
+    "name": "doFoo",
+    "params": Array [],
+    "returns": null,
+  },
+  Object {
+    "docblock": null,
+    "modifiers": Array [
+      "static",
+    ],
+    "name": "doBar",
+    "params": Array [],
+    "returns": null,
+  },
+]
+`;
+
+exports[`componentMethodsHandler function components finds static methods on a component in an assignment 1`] = `
+Array [
+  Object {
+    "docblock": null,
+    "modifiers": Array [
+      "static",
+    ],
+    "name": "doFoo",
+    "params": Array [],
+    "returns": null,
+  },
+  Object {
+    "docblock": null,
+    "modifiers": Array [
+      "static",
+    ],
+    "name": "doBar",
+    "params": Array [],
+    "returns": null,
+  },
+]
+`;
+
+exports[`componentMethodsHandler function components finds static methods on a function declaration 1`] = `
+Array [
+  Object {
+    "docblock": null,
+    "modifiers": Array [
+      "static",
+    ],
+    "name": "doFoo",
+    "params": Array [],
+    "returns": null,
+  },
+  Object {
+    "docblock": null,
+    "modifiers": Array [
+      "static",
+    ],
+    "name": "doBar",
+    "params": Array [],
+    "returns": null,
+  },
+]
+`;
+
 exports[`componentMethodsHandler should handle and ignore computed methods 1`] = `
 Array [
   Object {

--- a/src/utils/getMethodDocumentation.js
+++ b/src/utils/getMethodDocumentation.js
@@ -15,6 +15,7 @@ import getParameterName from './getParameterName';
 import getPropertyName from './getPropertyName';
 import getTypeAnnotation from './getTypeAnnotation';
 import type { FlowTypeDescriptor } from '../types';
+import resolveToValue from './resolveToValue';
 
 type MethodParameter = {
   name: string,
@@ -34,9 +35,17 @@ type MethodDocumentation = {
   returns: ?MethodReturn,
 };
 
+function getMethodFunctionExpression(methodPath) {
+  if (t.AssignmentExpression.check(methodPath.node)) {
+    return resolveToValue(methodPath.get('right'));
+  }
+  // Otherwise this is a method/property node
+  return methodPath.get('value');
+}
+
 function getMethodParamsDoc(methodPath) {
   const params = [];
-  const functionExpression = methodPath.get('value');
+  const functionExpression = getMethodFunctionExpression(methodPath);
 
   // Extract param flow types.
   functionExpression.get('params').each(paramPath => {
@@ -68,7 +77,7 @@ function getMethodParamsDoc(methodPath) {
 
 // Extract flow return type.
 function getMethodReturnDoc(methodPath) {
-  const functionExpression = methodPath.get('value');
+  const functionExpression = getMethodFunctionExpression(methodPath);
 
   if (functionExpression.node.returnType) {
     const returnType = getTypeAnnotation(functionExpression.get('returnType'));
@@ -83,6 +92,12 @@ function getMethodReturnDoc(methodPath) {
 }
 
 function getMethodModifiers(methodPath) {
+  if (t.AssignmentExpression.check(methodPath.node)) {
+    return ['static'];
+  }
+
+  // Otherwise this is a method/property node
+
   const modifiers = [];
 
   if (methodPath.node.static) {
@@ -104,21 +119,65 @@ function getMethodModifiers(methodPath) {
   return modifiers;
 }
 
-export default function getMethodDocumentation(
-  methodPath: NodePath,
-): ?MethodDocumentation {
-  if (methodPath.node.accessibility === 'private') {
+function getMethodName(methodPath) {
+  if (
+    t.AssignmentExpression.check(methodPath.node) &&
+    t.MemberExpression.check(methodPath.node.left)
+  ) {
+    const left = methodPath.node.left;
+    const property = left.property;
+    if (!left.computed) {
+      return property.name;
+    }
+    if (t.Literal.check(property)) {
+      return String(property.value);
+    }
+    return null;
+  }
+  return getPropertyName(methodPath);
+}
+
+function getMethodAccessibility(methodPath) {
+  if (t.AssignmentExpression.check(methodPath.node)) {
     return null;
   }
 
-  const name = getPropertyName(methodPath);
-  if (!name) return null;
+  // Otherwise this is a method/property node
+  return methodPath.node.accessibility;
+}
 
-  const docblock = getDocblock(methodPath);
+function getMethodDocblock(methodPath) {
+  if (t.AssignmentExpression.check(methodPath.node)) {
+    let path = methodPath;
+    do {
+      path = path.parent;
+    } while (path && !t.ExpressionStatement.check(path.node));
+    if (path) {
+      return getDocblock(path);
+    }
+    return null;
+  }
+
+  // Otherwise this is a method/property node
+  return getDocblock(methodPath);
+}
+
+// Gets the documentation object for a component method.
+// Component methods may be represented as class/object method/property nodes
+// or as assignment expresions of the form `Component.foo = function() {}`
+export default function getMethodDocumentation(
+  methodPath: NodePath,
+): ?MethodDocumentation {
+  if (getMethodAccessibility(methodPath) === 'private') {
+    return null;
+  }
+
+  const name = getMethodName(methodPath);
+  if (!name) return null;
 
   return {
     name,
-    docblock,
+    docblock: getMethodDocblock(methodPath),
     modifiers: getMethodModifiers(methodPath),
     params: getMethodParamsDoc(methodPath),
     returns: getMethodReturnDoc(methodPath),


### PR DESCRIPTION
Extends `componentMethodsHandler` to recognise static methods added to function components via assignment. Internally to the handler, methods may now be represented either by `AssignmentExpression` nodes or by object/class method nodes.