### PR TITLE
fix: avoid circular reference when resolving name from within assignment

### DIFF
--- a/src/handlers/__tests__/flowTypeHandler-test.js
+++ b/src/handlers/__tests__/flowTypeHandler-test.js
@@ -368,5 +368,25 @@ describe('flowTypeHandler', () => {
         },
       });
     });
+
+    it('resolves when the function is rebound and not inline', () => {
+      const src = `
+        import React from 'react';
+        type Props = { foo: string };
+        let Component = (props: Props, ref) => <div ref={ref}>{props.foo}</div>;
+        Component = React.forwardRef(Component);
+      `;
+      flowTypeHandler(
+        documentation,
+        parse(src).get('body', 3, 'expression', 'right'),
+      );
+      expect(documentation.descriptors).toEqual({
+        foo: {
+          flowType: {},
+          required: true,
+          description: '',
+        },
+      });
+    });
   });
 });

--- a/src/utils/__tests__/resolveToValue-test.js
+++ b/src/utils/__tests__/resolveToValue-test.js
@@ -109,6 +109,26 @@ describe('resolveToValue', () => {
 
       expect(resolveToValue(path)).toEqualASTNode(builders.literal(42));
     });
+
+    it('resolves to other assigned value if ref is in an assignment lhs', () => {
+      const path = parsePath(
+        ['var foo;', 'foo = 42;', 'foo = wrap(foo);'].join('\n'),
+      );
+
+      expect(resolveToValue(path.get('left'))).toEqualASTNode(
+        builders.literal(42),
+      );
+    });
+
+    it('resolves to other assigned value if ref is in an assignment rhs', () => {
+      const path = parsePath(
+        ['var foo;', 'foo = 42;', 'foo = wrap(foo);'].join('\n'),
+      );
+
+      expect(resolveToValue(path.get('right', 'arguments', 0))).toEqualASTNode(
+        builders.literal(42),
+      );
+    });
   });
 
   describe('ImportDeclaration', () => {

--- a/src/utils/resolveToValue.js
+++ b/src/utils/resolveToValue.js
@@ -72,22 +72,32 @@ function findScopePath(paths: Array<NodePath>, path: NodePath): ?NodePath {
  * Tries to find the last value assigned to `name` in the scope created by
  * `scope`. We are not descending into any statements (blocks).
  */
-function findLastAssignedValue(scope, name) {
+function findLastAssignedValue(scope, idPath) {
   const results = [];
+  const name = idPath.node.name;
 
   traverseShallow(scope.path.node, {
     visitAssignmentExpression: function(path) {
       const node = path.node;
       // Skip anything that is not an assignment to a variable with the
       // passed name.
+      // Ensure the LHS isn't the reference we're trying to resolve.
       if (
         !t.Identifier.check(node.left) ||
+        node.left === idPath.node ||
         node.left.name !== name ||
         node.operator !== '='
       ) {
         return this.traverse(path);
       }
-      results.push(path.get('right'));
+      // Ensure the RHS doesn't contain the reference we're trying to resolve.
+      const candidatePath = path.get('right');
+      for (let p = idPath; p && p.node != null; p = p.parent) {
+        if (p.node === candidatePath.node) {
+          return this.traverse(path);
+        }
+      }
+      results.push(candidatePath);
       return false;
     },
   });
@@ -159,7 +169,7 @@ export default function resolveToValue(path: NodePath): NodePath {
       // The variable may be assigned a different value after initialization.
       // We are first trying to find all assignments to the variable in the
       // block where it is defined (i.e. we are not traversing into statements)
-      resolvedPath = findLastAssignedValue(scope, node.name);
+      resolvedPath = findLastAssignedValue(scope, path);
       if (!resolvedPath) {
         const bindings = scope.getBindings()[node.name];
         resolvedPath = findScopePath(bindings, path);


### PR DESCRIPTION
When calling `resolveToValue`, currently it may resolve to an expression containing the very reference we were trying to resolve, even though the correct resolution in terms of program flow is an earlier assignment. In particular, this arises in some handlers when we reassign a variable holding a component, e.g when wrapping it with a HOC:

```jsx
import React from 'react';
let Component = (props, ref) => {};
//              ^
//              expected resolution
Component = React.forwardRef(     Component     );
//          ^                     ^
//          actual resolution     reference
```

Here, we minimally tweak `resolveToValue` to (1) take an Identifier path instead of a name; and (2) not resolve to an assignment expression's RHS if the assignment contains the reference we're trying to resolve. Note that this isn't a complete solution for tracking reassignments (e.g. it doesn't account for ordering or more complex ASTs) but it should be a satisfactory fix for this particular pattern.