### PR TITLE
fix: infer displayName given forwardRef() node

### DIFF
--- a/src/handlers/__tests__/displayNameHandler-test.js
+++ b/src/handlers/__tests__/displayNameHandler-test.js
@@ -181,6 +181,17 @@ describe('defaultPropsHandler', () => {
       expect(documentation.displayName).toBe('Foo');
     });
 
+    it('considers the variable name when handling forwardRef', () => {
+      const definition = statement(
+        [
+          'var Foo = React.forwardRef(() => {});',
+          'import React from "react";',
+        ].join('\n'),
+      ).get('declarations', 0, 'init');
+      expect(() => displayNameHandler(documentation, definition)).not.toThrow();
+      expect(documentation.displayName).toBe('Foo');
+    });
+
     it('considers the variable name on assign', () => {
       const definition = statement('Foo = () => {};').get(
         'expression',
@@ -197,6 +208,17 @@ describe('defaultPropsHandler', () => {
         'arguments',
         0,
       );
+      expect(() => displayNameHandler(documentation, definition)).not.toThrow();
+      expect(documentation.displayName).toBe('Foo');
+    });
+
+    it('considers the variable name on assign when handling forwardRef call', () => {
+      const definition = statement(
+        [
+          'Foo = React.forwardRef(() => {});',
+          'import React from "react";',
+        ].join('\n'),
+      ).get('expression', 'right');
       expect(() => displayNameHandler(documentation, definition)).not.toThrow();
       expect(documentation.displayName).toBe('Foo');
     });

--- a/src/handlers/displayNameHandler.js
+++ b/src/handlers/displayNameHandler.js
@@ -10,6 +10,7 @@
 import { namedTypes as t } from 'ast-types';
 import getMemberValuePath from '../utils/getMemberValuePath';
 import getNameOrValue from '../utils/getNameOrValue';
+import isReactForwardRefCall from '../utils/isReactForwardRefCall';
 import resolveToValue from '../utils/resolveToValue';
 import resolveFunctionDefinitionToReturnValue from '../utils/resolveFunctionDefinitionToReturnValue';
 import type Documentation from '../Documentation';
@@ -29,7 +30,8 @@ export default function displayNameHandler(
       documentation.set('displayName', getNameOrValue(path.get('id')));
     } else if (
       t.ArrowFunctionExpression.check(path.node) ||
-      t.FunctionExpression.check(path.node)
+      t.FunctionExpression.check(path.node) ||
+      isReactForwardRefCall(path)
     ) {
       let currentPath = path;
       while (currentPath.parent) {


### PR DESCRIPTION
Makes `displayNameHandler` succeed when invoked on the `CallExpression` node representing a ` forwardRef` call, rather than on the function expression that is its argument. (The latter scenario already works and is what the existing tests cover.)