### PR TITLE
Ensure componentMethodsHandler ignores private properties

### DIFF
--- a/src/handlers/__tests__/componentMethodsHandler-test.js
+++ b/src/handlers/__tests__/componentMethodsHandler-test.js
@@ -156,6 +156,25 @@ describe('componentMethodsHandler', () => {
     expect(documentation.methods).toMatchSnapshot();
   });
 
+  it('should handle and ignore private properties', () => {
+    const src = `
+      class Test extends React.Component {
+        #privateProperty = () => {
+          console.log('Do something');
+        }
+
+        componentDidMount() {}
+
+        render() {
+          return null;
+        }
+      }
+    `;
+
+    componentMethodsHandler(documentation, parse(src).get('body', 0));
+    expect(documentation.methods.length).toBe(0);
+  });
+
   describe('function components', () => {
     it('no methods', () => {
       const src = `

--- a/src/handlers/componentMethodsHandler.js
+++ b/src/handlers/componentMethodsHandler.js
@@ -17,6 +17,11 @@ import match from '../utils/match';
 import { traverseShallow } from '../utils/traverse';
 import resolveToValue from '../utils/resolveToValue';
 
+function isPublicClassProperty(path) {
+  return (
+    t.ClassProperty.check(path.node) && !t.ClassPrivateProperty.check(path.node)
+  );
+}
 /**
  * The following values/constructs are considered methods:
  *
@@ -28,7 +33,7 @@ import resolveToValue from '../utils/resolveToValue';
 function isMethod(path) {
   const isProbablyMethod =
     (t.MethodDefinition.check(path.node) && path.node.kind !== 'constructor') ||
-    ((t.ClassProperty.check(path.node) || t.Property.check(path.node)) &&
+    ((isPublicClassProperty(path) || t.Property.check(path.node)) &&
       t.Function.check(path.get('value').node));
 
   return isProbablyMethod && !isReactComponentMethod(path);


### PR DESCRIPTION
Currently, react-docgen fails to parse a component that uses private properties such as

```jsx
class MyComponent extends React.Component {
    #privateCallback = () => {
      console.log('Do something');
    }

    render() {
       return <button onClick={this.#privateCallback}>Click me</button>
    }
}
```

This fix allows react-docgen to parse this code.

### Notes

- Surprisingly `t.ClassProperty.check` returns true even if the property is a `ClassPrivateProperty`. This explains the nature of the change, and why there seems to be a seemingly contradicting line: `t.ClassProperty.check(path.node) && !t.ClassPrivateProperty.check(path.node)`