### PR TITLE
Improving resolver documentation 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Type: `(ast: ASTNode, parser: { parse: (string) => ASTNode }) => (NodePath | Arr
 
 Given an AST and a reference to the parser, it returns an (array of) NodePath which represents the component definition.
 
-*Built-in resolvers are available under the `resolver` property, e.g. `reactDocgen.resolver.findAllComponentDefinitions`*
+*Built-in resolvers are available under the `resolver` property, e.g. `reactDocs.parse(src, reactDocgen.resolver.findAllComponentDefinitions)`*
 
 #### handlers
 


### PR DESCRIPTION
I tried to understand how to use the resolvers and was not clear for me how to do that until googling and landing in this issue https://github.com/reactjs/react-docgen/issues/244 which asked to improve the documentation, which ended with this PR https://github.com/reactjs/react-docgen/pull/328 which improved as well the documentation, but wasn't that clear to me, because I read that part of the documentation, I think adding the `reactDocs.parse` is crystal clear how to use it.