### PR TITLE
Version bump to fix dependency resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-docgen",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "A CLI and toolkit to extract information from React components for documentation generation.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "react-docgen",
+  "name": "@ethancrook/react-docgen",
   "version": "5.3.1",
   "description": "A CLI and toolkit to extract information from React components for documentation generation.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/reactjs/react-docgen.git"
+    "url": "git+https://github.com/ethancrook99/react-docgen.git"
   },
   "bugs": {
     "url": "https://github.com/reactjs/react-docgen/issues"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@ethancrook/react-docgen",
+  "name": "react-docgen",
   "version": "5.3.1",
   "description": "A CLI and toolkit to extract information from React components for documentation generation.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ethancrook99/react-docgen.git"
+    "url": "git+https://github.com/reactjs/react-docgen.git"
   },
   "bugs": {
     "url": "https://github.com/reactjs/react-docgen/issues"


### PR DESCRIPTION
Bumped version to 5.3.1 to fix dependencies that aren't resolving correctly. Specifically, `ast-types` is resolving to `^0.13.4` as the dependency for this project, when it should be resolving to `^0.14.2`. Going along with this PR, the new version would also need to be published to NPM. 