### PR TITLE
Fix "Buffer is not defined" on website

### DIFF
--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -36,8 +36,6 @@ const plugins = [
   }),
   new webpack.ProvidePlugin({
     process: 'process',
-  }),
-  new webpack.ProvidePlugin({
     Buffer: ['buffer', 'Buffer'],
   }),
 ];

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -37,6 +37,9 @@ const plugins = [
   new webpack.ProvidePlugin({
     process: 'process',
   }),
+  new webpack.ProvidePlugin({
+    Buffer: ['buffer', 'Buffer'],
+  }),
 ];
 
 module.exports = {


### PR DESCRIPTION
I believe this fix the playground, with a bug introduced in https://github.com/reactjs/react-docgen/commit/a3789033ee5507f8f0214847e638b4b47cfc0d4f.

 http://reactcommunity.org/react-docgen/

![Screen Shot 2021-02-14 at 12 56 16 AM](https://user-images.githubusercontent.com/4825444/107872487-78a59c80-6e5f-11eb-9be5-358c1f6a3e12.png)
![Screen Shot 2021-02-14 at 12 51 06 AM](https://user-images.githubusercontent.com/4825444/107872489-7a6f6000-6e5f-11eb-9192-58dd803c9f17.png)
