### PR TITLE
fix: Remove usage of ast-type builders

### DIFF
--- a/src/utils/__tests__/__snapshots__/resolveObjectKeysToArray-test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/resolveObjectKeysToArray-test.ts.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`resolveObjectKeysToArray can resolve imported objects passed to Object.keys 1`] = `
+Array [
+  "\\"bar\\"",
+  "\\"foo\\"",
+  "\\"1\\"",
+  "\\"2\\"",
+  "\\"3\\"",
+  "\\"baz\\"",
+]
+`;
+
+exports[`resolveObjectKeysToArray can resolve spreads from imported objects 1`] = `
+Array [
+  "\\"foo\\"",
+  "\\"baz\\"",
+  "\\"bar\\"",
+]
+`;
+
+exports[`resolveObjectKeysToArray resolves Object.keys but ignores duplicates 1`] = `
+Array [
+  "\\"boo\\"",
+  "\\"foo\\"",
+  "\\"doo\\"",
+]
+`;
+
+exports[`resolveObjectKeysToArray resolves Object.keys but ignores duplicates with getter and setter 1`] = `
+Array [
+  "\\"x\\"",
+]
+`;
+
+exports[`resolveObjectKeysToArray resolves Object.keys when using getters 1`] = `
+Array [
+  "\\"boo\\"",
+  "\\"foo\\"",
+  "\\"bar\\"",
+]
+`;
+
+exports[`resolveObjectKeysToArray resolves Object.keys when using resolvable spread 1`] = `
+Array [
+  "\\"boo\\"",
+  "\\"foo\\"",
+  "\\"doo\\"",
+]
+`;
+
+exports[`resolveObjectKeysToArray resolves Object.keys when using setters 1`] = `
+Array [
+  "\\"boo\\"",
+  "\\"foo\\"",
+  "\\"bar\\"",
+]
+`;
+
+exports[`resolveObjectKeysToArray resolves Object.keys with identifiers 1`] = `
+Array [
+  "\\"bar\\"",
+  "\\"foo\\"",
+]
+`;
+
+exports[`resolveObjectKeysToArray resolves Object.keys with literals 1`] = `
+Array [
+  "\\"bar\\"",
+  "\\"5\\"",
+]
+`;
+
+exports[`resolveObjectKeysToArray resolves Object.keys with literals as computed key 1`] = `
+Array [
+  "\\"bar\\"",
+  "\\"5\\"",
+]
+`;

--- a/src/utils/__tests__/__snapshots__/resolveObjectValuesToArray-test.ts.snap
+++ b/src/utils/__tests__/__snapshots__/resolveObjectValuesToArray-test.ts.snap
@@ -1,0 +1,82 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`resolveObjectValuesToArray can resolve imported objects passed to Object.values 1`] = `
+Array [
+  "\\"bar\\"",
+  "\\"foo\\"",
+  "0",
+  "5",
+  "null",
+  "null",
+  "7",
+  "\\"foo\\"",
+]
+`;
+
+exports[`resolveObjectValuesToArray can resolve spreads from imported objects 1`] = `
+Array [
+  "\\"bar\\"",
+  "\\"baz\\"",
+  "\\"foo\\"",
+]
+`;
+
+exports[`resolveObjectValuesToArray resolves Object.values but ignores duplicates 1`] = `
+Array [
+  "1",
+  "5",
+  "2",
+]
+`;
+
+exports[`resolveObjectValuesToArray resolves Object.values but ignores duplicates with getter and setter 1`] = `Array []`;
+
+exports[`resolveObjectValuesToArray resolves Object.values when using getters 1`] = `
+Array [
+  "1",
+  "2",
+]
+`;
+
+exports[`resolveObjectValuesToArray resolves Object.values when using resolvable spread 1`] = `
+Array [
+  "1",
+  "4",
+  "2",
+]
+`;
+
+exports[`resolveObjectValuesToArray resolves Object.values when using setters 1`] = `
+Array [
+  "1",
+  "2",
+]
+`;
+
+exports[`resolveObjectValuesToArray resolves Object.values with literals as computed key 1`] = `
+Array [
+  "2",
+  "1",
+]
+`;
+
+exports[`resolveObjectValuesToArray resolves Object.values with numbers 1`] = `
+Array [
+  "0",
+  "5",
+]
+`;
+
+exports[`resolveObjectValuesToArray resolves Object.values with strings 1`] = `
+Array [
+  "\\"bar\\"",
+  "\\"foo\\"",
+]
+`;
+
+exports[`resolveObjectValuesToArray resolves Object.values with undefined or null 1`] = `
+Array [
+  "null",
+  "null",
+]
+`;

--- a/src/utils/__tests__/resolveObjectKeysToArray-test.ts
+++ b/src/utils/__tests__/resolveObjectKeysToArray-test.ts
@@ -1,4 +1,3 @@
-import { builders } from 'ast-types';
 import {
   statement,
   noopImporter,
@@ -32,12 +31,7 @@ describe('resolveObjectKeysToArray', () => {
       ['var foo = { bar: 1, foo: 2 };', 'Object.keys(foo);'].join('\n'),
     );
 
-    expect(resolveObjectKeysToArray(path, noopImporter)).toEqualASTNode(
-      builders.arrayExpression([
-        builders.literal('bar'),
-        builders.literal('foo'),
-      ]),
-    );
+    expect(resolveObjectKeysToArray(path, noopImporter)).toMatchSnapshot();
   });
 
   it('resolves Object.keys with literals', () => {
@@ -45,12 +39,7 @@ describe('resolveObjectKeysToArray', () => {
       ['var foo = { "bar": 1, 5: 2 };', 'Object.keys(foo);'].join('\n'),
     );
 
-    expect(resolveObjectKeysToArray(path, noopImporter)).toEqualASTNode(
-      builders.arrayExpression([
-        builders.literal('bar'),
-        builders.literal('5'),
-      ]),
-    );
+    expect(resolveObjectKeysToArray(path, noopImporter)).toMatchSnapshot();
   });
 
   it('resolves Object.keys with literals as computed key', () => {
@@ -58,12 +47,7 @@ describe('resolveObjectKeysToArray', () => {
       ['var foo = { ["bar"]: 1, [5]: 2};', 'Object.keys(foo);'].join('\n'),
     );
 
-    expect(resolveObjectKeysToArray(path, noopImporter)).toEqualASTNode(
-      builders.arrayExpression([
-        builders.literal('bar'),
-        builders.literal('5'),
-      ]),
-    );
+    expect(resolveObjectKeysToArray(path, noopImporter)).toMatchSnapshot();
   });
 
   it('resolves Object.keys when using resolvable spread', () => {
@@ -75,13 +59,7 @@ describe('resolveObjectKeysToArray', () => {
       ].join('\n'),
     );
 
-    expect(resolveObjectKeysToArray(path, noopImporter)).toEqualASTNode(
-      builders.arrayExpression([
-        builders.literal('boo'),
-        builders.literal('foo'),
-        builders.literal('doo'),
-      ]),
-    );
+    expect(resolveObjectKeysToArray(path, noopImporter)).toMatchSnapshot();
   });
 
   it('resolves Object.keys when using getters', () => {
@@ -91,13 +69,7 @@ describe('resolveObjectKeysToArray', () => {
       ),
     );
 
-    expect(resolveObjectKeysToArray(path, noopImporter)).toEqualASTNode(
-      builders.arrayExpression([
-        builders.literal('boo'),
-        builders.literal('foo'),
-        builders.literal('bar'),
-      ]),
-    );
+    expect(resolveObjectKeysToArray(path, noopImporter)).toMatchSnapshot();
   });
 
   it('resolves Object.keys when using setters', () => {
@@ -108,13 +80,7 @@ describe('resolveObjectKeysToArray', () => {
       ].join('\n'),
     );
 
-    expect(resolveObjectKeysToArray(path, noopImporter)).toEqualASTNode(
-      builders.arrayExpression([
-        builders.literal('boo'),
-        builders.literal('foo'),
-        builders.literal('bar'),
-      ]),
-    );
+    expect(resolveObjectKeysToArray(path, noopImporter)).toMatchSnapshot();
   });
 
   it('resolves Object.keys but ignores duplicates', () => {
@@ -126,13 +92,7 @@ describe('resolveObjectKeysToArray', () => {
       ].join('\n'),
     );
 
-    expect(resolveObjectKeysToArray(path, noopImporter)).toEqualASTNode(
-      builders.arrayExpression([
-        builders.literal('boo'),
-        builders.literal('foo'),
-        builders.literal('doo'),
-      ]),
-    );
+    expect(resolveObjectKeysToArray(path, noopImporter)).toMatchSnapshot();
   });
 
   it('resolves Object.keys but ignores duplicates with getter and setter', () => {
@@ -142,9 +102,7 @@ describe('resolveObjectKeysToArray', () => {
       ),
     );
 
-    expect(resolveObjectKeysToArray(path, noopImporter)).toEqualASTNode(
-      builders.arrayExpression([builders.literal('x')]),
-    );
+    expect(resolveObjectKeysToArray(path, noopImporter)).toMatchSnapshot();
   });
 
   it('does not resolve Object.keys when using unresolvable spread', () => {
@@ -169,16 +127,7 @@ describe('resolveObjectKeysToArray', () => {
       Object.keys(foo);
     `);
 
-    expect(resolveObjectKeysToArray(path, mockImporter)).toEqualASTNode(
-      builders.arrayExpression([
-        builders.literal('bar'),
-        builders.literal('foo'),
-        builders.literal(1),
-        builders.literal(2),
-        builders.literal(3),
-        builders.literal('baz'),
-      ]),
-    );
+    expect(resolveObjectKeysToArray(path, mockImporter)).toMatchSnapshot();
   });
 
   it('can resolve spreads from imported objects', () => {
@@ -188,12 +137,6 @@ describe('resolveObjectKeysToArray', () => {
       Object.keys(abc);
     `);
 
-    expect(resolveObjectKeysToArray(path, mockImporter)).toEqualASTNode(
-      builders.arrayExpression([
-        builders.literal('foo'),
-        builders.literal('baz'),
-        builders.literal('bar'),
-      ]),
-    );
+    expect(resolveObjectKeysToArray(path, mockImporter)).toMatchSnapshot();
   });
 });

--- a/src/utils/__tests__/resolveObjectValuesToArray-test.ts
+++ b/src/utils/__tests__/resolveObjectValuesToArray-test.ts
@@ -1,4 +1,3 @@
-import { builders } from 'ast-types';
 import {
   statement,
   noopImporter,
@@ -34,12 +33,7 @@ describe('resolveObjectValuesToArray', () => {
       ['var foo = { 1: "bar", 2: "foo" };', 'Object.values(foo);'].join('\n'),
     );
 
-    expect(resolveObjectValuesToArray(path, noopImporter)).toEqualASTNode(
-      builders.arrayExpression([
-        builders.literal('bar'),
-        builders.literal('foo'),
-      ]),
-    );
+    expect(resolveObjectValuesToArray(path, noopImporter)).toMatchSnapshot();
   });
 
   it('resolves Object.values with numbers', () => {
@@ -47,9 +41,7 @@ describe('resolveObjectValuesToArray', () => {
       ['var foo = { 1: 0, 2: 5 };', 'Object.values(foo);'].join('\n'),
     );
 
-    expect(resolveObjectValuesToArray(path, noopImporter)).toEqualASTNode(
-      builders.arrayExpression([builders.literal(0), builders.literal(5)]),
-    );
+    expect(resolveObjectValuesToArray(path, noopImporter)).toMatchSnapshot();
   });
 
   it('resolves Object.values with undefined or null', () => {
@@ -59,12 +51,7 @@ describe('resolveObjectValuesToArray', () => {
       ),
     );
 
-    expect(resolveObjectValuesToArray(path, noopImporter)).toEqualASTNode(
-      builders.arrayExpression([
-        builders.literal(null),
-        builders.literal(null),
-      ]),
-    );
+    expect(resolveObjectValuesToArray(path, noopImporter)).toMatchSnapshot();
   });
 
   it('resolves Object.values with literals as computed key', () => {
@@ -72,9 +59,7 @@ describe('resolveObjectValuesToArray', () => {
       ['var foo = { ["bar"]: 1, [5]: 2};', 'Object.values(foo);'].join('\n'),
     );
 
-    expect(resolveObjectValuesToArray(path, noopImporter)).toEqualASTNode(
-      builders.arrayExpression([builders.literal(2), builders.literal(1)]),
-    );
+    expect(resolveObjectValuesToArray(path, noopImporter)).toMatchSnapshot();
   });
 
   it('does not resolve Object.values with complex computed key', () => {
@@ -94,13 +79,7 @@ describe('resolveObjectValuesToArray', () => {
       ].join('\n'),
     );
 
-    expect(resolveObjectValuesToArray(path, noopImporter)).toEqualASTNode(
-      builders.arrayExpression([
-        builders.literal(1),
-        builders.literal(4),
-        builders.literal(2),
-      ]),
-    );
+    expect(resolveObjectValuesToArray(path, noopImporter)).toMatchSnapshot();
   });
 
   it('resolves Object.values when using getters', () => {
@@ -111,9 +90,7 @@ describe('resolveObjectValuesToArray', () => {
       ].join('\n'),
     );
 
-    expect(resolveObjectValuesToArray(path, noopImporter)).toEqualASTNode(
-      builders.arrayExpression([builders.literal(1), builders.literal(2)]),
-    );
+    expect(resolveObjectValuesToArray(path, noopImporter)).toMatchSnapshot();
   });
 
   it('resolves Object.values when using setters', () => {
@@ -124,9 +101,7 @@ describe('resolveObjectValuesToArray', () => {
       ].join('\n'),
     );
 
-    expect(resolveObjectValuesToArray(path, noopImporter)).toEqualASTNode(
-      builders.arrayExpression([builders.literal(1), builders.literal(2)]),
-    );
+    expect(resolveObjectValuesToArray(path, noopImporter)).toMatchSnapshot();
   });
 
   it('resolves Object.values but ignores duplicates', () => {
@@ -138,13 +113,7 @@ describe('resolveObjectValuesToArray', () => {
       ].join('\n'),
     );
 
-    expect(resolveObjectValuesToArray(path, noopImporter)).toEqualASTNode(
-      builders.arrayExpression([
-        builders.literal(1),
-        builders.literal(5),
-        builders.literal(2),
-      ]),
-    );
+    expect(resolveObjectValuesToArray(path, noopImporter)).toMatchSnapshot();
   });
 
   it('resolves Object.values but ignores duplicates with getter and setter', () => {
@@ -154,9 +123,7 @@ describe('resolveObjectValuesToArray', () => {
       ),
     );
 
-    expect(resolveObjectValuesToArray(path, noopImporter)).toEqualASTNode(
-      builders.arrayExpression([]),
-    );
+    expect(resolveObjectValuesToArray(path, noopImporter)).toMatchSnapshot();
   });
 
   it('does not resolve Object.values when using unresolvable spread', () => {
@@ -175,18 +142,7 @@ describe('resolveObjectValuesToArray', () => {
       Object.values(foo);
     `);
 
-    expect(resolveObjectValuesToArray(path, mockImporter)).toEqualASTNode(
-      builders.arrayExpression([
-        builders.literal('bar'),
-        builders.literal('foo'),
-        builders.literal(0),
-        builders.literal(5),
-        builders.literal(null),
-        builders.literal(null),
-        builders.literal(7),
-        builders.literal('foo'),
-      ]),
-    );
+    expect(resolveObjectValuesToArray(path, mockImporter)).toMatchSnapshot();
   });
 
   it('can resolve spreads from imported objects', () => {
@@ -196,12 +152,6 @@ describe('resolveObjectValuesToArray', () => {
       Object.values(abc);
     `);
 
-    expect(resolveObjectValuesToArray(path, mockImporter)).toEqualASTNode(
-      builders.arrayExpression([
-        builders.literal('bar'),
-        builders.literal('baz'),
-        builders.literal('foo'),
-      ]),
-    );
+    expect(resolveObjectValuesToArray(path, mockImporter)).toMatchSnapshot();
   });
 });

--- a/src/utils/getPropType.ts
+++ b/src/utils/getPropType.ts
@@ -51,13 +51,16 @@ function getPropTypeOneOf(
   importer: Importer,
 ): PropTypeDescriptor {
   const type: PropTypeDescriptor = { name: 'enum' };
-  let value: NodePath | null = resolveToValue(argumentPath, importer);
+  const value: NodePath | null = resolveToValue(argumentPath, importer);
   if (!t.ArrayExpression.check(value.node)) {
-    value =
+    const objectValues =
       resolveObjectKeysToArray(value, importer) ||
       resolveObjectValuesToArray(value, importer);
-    if (value) {
-      type.value = getEnumValues(value, importer);
+    if (objectValues) {
+      type.value = objectValues.map(objectValue => ({
+        value: objectValue,
+        computed: false,
+      }));
     } else {
       // could not easily resolve to an Array, let's print the original value
       type.computed = true;

--- a/src/utils/resolveObjectKeysToArray.ts
+++ b/src/utils/resolveObjectKeysToArray.ts
@@ -1,9 +1,4 @@
-import {
-  ASTNode,
-  builders,
-  NodePath as NodePathConstructor,
-  namedTypes as t,
-} from 'ast-types';
+import { ASTNode, namedTypes as t } from 'ast-types';
 import type { NodePath } from 'ast-types/lib/node-path';
 import resolveToValue from './resolveToValue';
 import type { Importer } from '../parse';
@@ -111,7 +106,7 @@ export function resolveObjectToNameArray(
 export default function resolveObjectKeysToArray(
   path: NodePath,
   importer: Importer,
-): NodePath | null {
+): string[] | null {
   const node = path.node;
 
   if (isObjectKeysCall(node)) {
@@ -124,9 +119,9 @@ export default function resolveObjectKeysToArray(
     if (values) {
       const nodes = values
         .filter((value, index, array) => array.indexOf(value) === index)
-        .map(value => builders.literal(value));
+        .map(value => `"${value}"`);
 
-      return new NodePathConstructor(builders.arrayExpression(nodes));
+      return nodes;
     }
   }
 

--- a/src/utils/resolveObjectValuesToArray.ts
+++ b/src/utils/resolveObjectValuesToArray.ts
@@ -1,9 +1,4 @@
-import {
-  ASTNode,
-  NodePath as NodePathConstructor,
-  builders,
-  namedTypes as t,
-} from 'ast-types';
+import { ASTNode, namedTypes as t } from 'ast-types';
 import resolveToValue from './resolveToValue';
 import type { Importer } from '../parse';
 import type { NodePath } from 'ast-types/lib/node-path';
@@ -132,7 +127,7 @@ export function resolveObjectToPropMap(
 export default function resolveObjectValuesToArray(
   path: NodePath,
   importer: Importer,
-): NodePath | null {
+): string[] | null {
   const node = path.node;
 
   if (isObjectValuesCall(node)) {
@@ -147,11 +142,13 @@ export default function resolveObjectValuesToArray(
         const value = propMap.values[prop] as Parameters<LiteralBuilder>[0];
 
         return typeof value === 'undefined'
-          ? builders.literal(null)
-          : builders.literal(value);
+          ? 'null'
+          : typeof value === 'string'
+          ? `"${value}"`
+          : `${value}`;
       });
 
-      return new NodePathConstructor(builders.arrayExpression(nodes));
+      return nodes;
     }
   }
 


### PR DESCRIPTION
BREAKING CHANGE: The helpers `resolveObjectValuesToArray` and `resolveObjectKeysToArray` return now `string[]` instead of a `NodePath`