### PR TITLE
fix(ts): parse jsdoc comment for ts structs

### DIFF
--- a/packages/react-docgen/src/Documentation.ts
+++ b/packages/react-docgen/src/Documentation.ts
@@ -117,6 +117,7 @@ export interface ObjectSignatureType<T = FunctionSignatureType>
     properties: Array<{
       key: TypeDescriptor<T> | string;
       value: TypeDescriptor<T>;
+      description?: string;
     }>;
     constructor?: TypeDescriptor<T>;
   };

--- a/packages/react-docgen/src/utils/getTSType.ts
+++ b/packages/react-docgen/src/utils/getTSType.ts
@@ -36,6 +36,7 @@ import type {
   RestElement,
   TypeScript,
 } from '@babel/types';
+import { getDocblock } from './docblock';
 
 const tsTypes = {
   TSAnyKeyword: 'any',
@@ -188,9 +189,17 @@ function handleTSTypeLiteral(
       if (!propName) {
         return;
       }
+      const docblock = getDocblock(param);
+      let doc = {};
+
+      if (docblock) {
+        doc = { description: docblock };
+      }
+
       type.signature.properties.push({
         key: propName,
         value: getTSTypeWithRequirements(typeAnnotation, typeParams),
+        ...doc,
       });
     } else if (param.isTSCallSignatureDeclaration()) {
       type.signature.constructor = handleTSFunctionType(param, typeParams);

--- a/packages/react-docgen/tests/integration/__fixtures__/component_22.tsx
+++ b/packages/react-docgen/tests/integration/__fixtures__/component_22.tsx
@@ -6,6 +6,19 @@ type Props = {
   center?: boolean,
   right?: boolean,
   justify?: boolean,
+  /**
+   * position doc
+   */
+  position: {
+    /**
+     * x coordinate doc
+     */
+    x: number,
+    /**
+     * y coordinate doc
+     */
+    y: number
+  }
 };
 
 /**

--- a/packages/react-docgen/tests/integration/__snapshots__/integration-test.ts.snap
+++ b/packages/react-docgen/tests/integration/__snapshots__/integration-test.ts.snap
@@ -1228,6 +1228,44 @@ exports[`integration fixtures processes component "component_22.tsx" without err
           "name": "boolean",
         },
       },
+      "position": {
+        "description": "position doc",
+        "required": true,
+        "tsType": {
+          "name": "signature",
+          "raw": "{
+  /**
+   * x coordinate doc
+   */
+  x: number,
+  /**
+   * y coordinate doc
+   */
+  y: number
+}",
+          "signature": {
+            "properties": [
+              {
+                "description": "x coordinate doc",
+                "key": "x",
+                "value": {
+                  "name": "number",
+                  "required": true,
+                },
+              },
+              {
+                "description": "y coordinate doc",
+                "key": "y",
+                "value": {
+                  "name": "number",
+                  "required": true,
+                },
+              },
+            ],
+          },
+          "type": "object",
+        },
+      },
       "right": {
         "description": "",
         "required": false,


### PR DESCRIPTION
Fixes: #496

For something like:
```tsx
type Props = {
  ...
  center: {
    /** x coordinate */
    x : number,
    /** y coordinate */
    y: number;
  }
}
```

Fill out `description` fields with appropriate jdoc for `x` and `y`