### PR TITLE
Require node 14.18 or later

### DIFF
--- a/packages/react-docgen/package.json
+++ b/packages/react-docgen/package.json
@@ -11,7 +11,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=14.18.0"
   },
   "main": "dist/main.js",
   "typings": "dist/main.d.ts",


### PR DESCRIPTION
In node 14.17 I'm seeing this:

```sh
% node --version
v14.17.0

Error: Cannot find module 'node:path'
Require stack:
-  node_modules/react-docgen/dist/babelParser.js

```

From docs it sounds like `node:` imports added to 14.18 or later (and also to 14.13.1 ???) https://nodejs.org/api/esm.html#node-imports