### PR TITLE
fix(ts): parse prop types if component inhereited from a HOC

### DIFF
--- a/packages/react-docgen/tests/integration/__fixtures__/ts-extends-hoc.tsx
+++ b/packages/react-docgen/tests/integration/__fixtures__/ts-extends-hoc.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface IProps {
+  /**
+   * description of value
+   */
+  value: string;
+}
+
+function Hoc<T>(v: React.Component<T>) : React.Component<T> {
+	return v;
+}
+
+class MyComponent extends Hoc(React.Component<IProps>) {
+  render() {
+    return <div className='s-c-z-example'/>;
+  }
+}
+export default MyComponent;

--- a/packages/react-docgen/tests/integration/__snapshots__/integration-test.ts.snap
+++ b/packages/react-docgen/tests/integration/__snapshots__/integration-test.ts.snap
@@ -2145,3 +2145,22 @@ exports[`integration fixtures processes component "test-all-imports.tsx" without
   },
 ]
 `;
+
+exports[`integration fixtures processes component "ts-extends-hoc.tsx" without errors 1`] = `
+[
+  {
+    "description": "",
+    "displayName": "MyComponent",
+    "methods": [],
+    "props": {
+      "value": {
+        "description": "description of value",
+        "required": true,
+        "tsType": {
+          "name": "string",
+        },
+      },
+    },
+  },
+]
+`;


### PR DESCRIPTION
Supports doc generation for the following, pattern:

```
function MyHoc<T>(v: React.Component<T>) : React.Component<T> {
	return v;
}

interface Props {
  ...
}

class MyComponent extends MyHoc(React.Component<Props>) {
  render() {
    return <div className='s-c-z-example'/>;
  }
}
```

It's only a heuristic, and has the assumption that a function call in extends is a HOC and the first argument to Hoc is a React.Component like thing.

Note sure I this is something you'd support or if this implementation is ok or not.

