### PR TITLE
Refactor resolveComponentDefinition into findComponentDefinition

### DIFF
--- a/.changeset/five-trainers-report.md
+++ b/.changeset/five-trainers-report.md
@@ -1,0 +1,10 @@
+---
+'react-docgen': major
+---
+
+Refactored `resolveComponentDefinition` utility.
+
+- Renamed to `findComponentDefinition`
+- Removed named export `isComponentDefinition`
+- The utility now does a lot more than previously, check out the commit to see
+  the changes in detail.

--- a/packages/react-docgen/src/utils/findComponentDefinition.ts
+++ b/packages/react-docgen/src/utils/findComponentDefinition.ts
@@ -5,9 +5,10 @@ import isReactCreateClassCall from './isReactCreateClassCall.js';
 import isReactForwardRefCall from './isReactForwardRefCall.js';
 import isStatelessComponent from './isStatelessComponent.js';
 import normalizeClassDefinition from './normalizeClassDefinition.js';
+import resolveHOC from './resolveHOC.js';
 import resolveToValue from './resolveToValue.js';
 
-export function isComponentDefinition(
+function isComponentDefinition(
   path: NodePath,
 ): path is NodePath<ComponentNode> {
   return (
@@ -18,7 +19,7 @@ export function isComponentDefinition(
   );
 }
 
-export default function resolveComponentDefinition(
+function resolveComponentDefinition(
   definition: NodePath<ComponentNode>,
 ): NodePath<ComponentNode> | null {
   if (isReactCreateClassCall(definition)) {
@@ -40,4 +41,19 @@ export default function resolveComponentDefinition(
   }
 
   return null;
+}
+
+export default function findComponentDefinition(
+  path: NodePath,
+): NodePath<ComponentNode> | null {
+  let resolvedPath = path;
+
+  if (!isComponentDefinition(resolvedPath)) {
+    resolvedPath = resolveToValue(resolveHOC(resolvedPath));
+    if (!isComponentDefinition(resolvedPath)) {
+      return null;
+    }
+  }
+
+  return resolveComponentDefinition(resolvedPath);
 }


### PR DESCRIPTION
Refactored `resolveComponentDefinition` utility.

- Renamed to `findComponentDefinition`
- Removed named export `isComponentDefinition`
- The utility now does a lot more than previously, check out the commit to see
  the changes in detail.