### PR TITLE
correctly support ObjectPattern and ArrayPattern in function signatures

### DIFF
--- a/.changeset/hungry-sheep-laugh.md
+++ b/.changeset/hungry-sheep-laugh.md
@@ -1,0 +1,5 @@
+---
+'react-docgen': patch
+---
+
+Fixed error with object and array patterns in function signatures.

--- a/packages/react-docgen/src/utils/__tests__/__snapshots__/getTSType-test.ts.snap
+++ b/packages/react-docgen/src/utils/__tests__/__snapshots__/getTSType-test.ts.snap
@@ -283,6 +283,52 @@ exports[`getTSType > detects function signature type with \`this\` parameter 1`]
 }
 `;
 
+exports[`getTSType > detects function signature type with object and array pattern 1`] = `
+{
+  "name": "signature",
+  "raw": "({ x }: { x: number }, [ f,s ]: Array<string>) => boolean",
+  "signature": {
+    "arguments": [
+      {
+        "name": "",
+        "type": {
+          "name": "signature",
+          "raw": "{ x: number }",
+          "signature": {
+            "properties": [
+              {
+                "key": "x",
+                "value": {
+                  "name": "number",
+                  "required": true,
+                },
+              },
+            ],
+          },
+          "type": "object",
+        },
+      },
+      {
+        "name": "",
+        "type": {
+          "elements": [
+            {
+              "name": "string",
+            },
+          ],
+          "name": "Array",
+          "raw": "Array<string>",
+        },
+      },
+    ],
+    "return": {
+      "name": "boolean",
+    },
+  },
+  "type": "function",
+}
+`;
+
 exports[`getTSType > detects function type with subtype 1`] = `
 {
   "elements": [

--- a/packages/react-docgen/src/utils/__tests__/getTSType-test.ts
+++ b/packages/react-docgen/src/utils/__tests__/getTSType-test.ts
@@ -296,6 +296,14 @@ describe('getTSType', () => {
     expect(getTSType(typePath)).toMatchSnapshot();
   });
 
+  test('detects function signature type with object and array pattern', () => {
+    const typePath = typeAlias(
+      'let x: ({ x }: { x: number }, [ f,s ]: Array<string>) => boolean;',
+    );
+
+    expect(getTSType(typePath)).toMatchSnapshot();
+  });
+
   test('detects callable signature type', () => {
     const typePath = typeAlias(
       'let x: { (str: string): string, token: string };',

--- a/packages/react-docgen/src/utils/getTSType.ts
+++ b/packages/react-docgen/src/utils/getTSType.ts
@@ -33,7 +33,6 @@ import type {
   TSTypeOperator,
   Identifier,
   TSTypeParameterDeclaration,
-  RestElement,
   TypeScript,
   TSQualifiedName,
   TSLiteralType,
@@ -357,8 +356,8 @@ function handleTSFunctionType(
 
         return;
       }
-    } else {
-      const restArgument = (param as NodePath<RestElement>).get('argument');
+    } else if (param.isRestElement()) {
+      const restArgument = param.get('argument');
 
       if (restArgument.isIdentifier()) {
         arg.name = restArgument.node.name;

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 packages:
-  - 'benchmark/'
+  - 'benchmark'
   - 'packages/*'


### PR DESCRIPTION
Fixes #827 

