### PR TITLE
Only check identifiers in getMemberExpressionValuePath

### DIFF
--- a/.changeset/late-numbers-raise.md
+++ b/.changeset/late-numbers-raise.md
@@ -1,0 +1,5 @@
+---
+'react-docgen': patch
+---
+
+Fixed crash when classes with private fields are used

--- a/packages/react-docgen/src/utils/__tests__/getMemberExpressionValuePath-test.ts
+++ b/packages/react-docgen/src/utils/__tests__/getMemberExpressionValuePath-test.ts
@@ -15,6 +15,27 @@ describe('getMemberExpressionValuePath', () => {
       );
     });
 
+    test('ignores unrelated private field', () => {
+      const def = parse.statement(
+        `
+        class Foo {
+          #isprivate = {};
+
+          classMethod() {
+            this.#isprivate = {};
+          }
+        }
+        const Boo = () => {};
+        Boo.propTypes = {};
+      `,
+        1,
+      );
+
+      expect(getMemberExpressionValuePath(def, 'propTypes')).toBe(
+        def.parentPath.get('body')[2].get('expression').get('right'),
+      );
+    });
+
     test('takes the correct property definitions', () => {
       const def = parse.statement(`
         var Foo = () => {};

--- a/packages/react-docgen/src/utils/getMemberExpressionValuePath.ts
+++ b/packages/react-docgen/src/utils/getMemberExpressionValuePath.ts
@@ -87,7 +87,7 @@ const explodedVisitors = visitors.explode<TraverseState>({
       const property = memberPath.get('property');
 
       if (
-        (!memberPath.node.computed ||
+        ((!memberPath.node.computed && property.isIdentifier()) ||
           property.isStringLiteral() ||
           property.isNumericLiteral()) &&
         getNameOrValue(property) === state.memberName &&


### PR DESCRIPTION
Fixes #980 