### PR TITLE
Security: Unsafe File Write with User-Controlled Path

### DIFF
--- a/packages/react-docgen-cli/src/commands/parse/output/outputResult.ts
+++ b/packages/react-docgen-cli/src/commands/parse/output/outputResult.ts
@@ -1,4 +1,5 @@
 import { writeFile } from 'fs/promises';
+import { resolve } from 'path';
 import type { Documentation } from 'react-docgen';
 
 export default async function outputResult(
@@ -12,7 +13,12 @@ export default async function outputResult(
   );
 
   if (output) {
-    await writeFile(output, result, 'utf-8');
+    const resolvedOutput = resolve(output);
+    const cwd = resolve('.');
+    if (!resolvedOutput.startsWith(cwd)) {
+      throw new Error('Output path must be within the current working directory');
+    }
+    await writeFile(resolvedOutput, result, 'utf-8');
   } else {
     process.stdout.write(result + '\n');
   }


### PR DESCRIPTION
## Summary

Security: Unsafe File Write with User-Controlled Path

## Problem

**Severity**: `High` | **File**: `packages/react-docgen-cli/src/commands/parse/output/outputResult.ts:L8`

The `outputResult` function writes to a file path specified by the `output` option without any validation. If an attacker can control the `output` parameter (e.g., via CLI `--output` flag), they could write files to arbitrary locations on the filesystem, potentially overwriting critical files or achieving remote code execution by overwriting executable files.

## Solution

Validate and sanitize the `output` path to ensure it resolves within an expected output directory. Use `path.resolve()` and check that the resolved path starts with the allowed base directory. Consider using `fs.realpath()` to resolve symlinks before validation.

## Changes

- `packages/react-docgen-cli/src/commands/parse/output/outputResult.ts` (modified)